### PR TITLE
Support relative URLs in config file

### DIFF
--- a/src/app/utils/url.utils.ts
+++ b/src/app/utils/url.utils.ts
@@ -14,7 +14,7 @@ export class UrlUtils {
     }
 
     public extractIdFieldName(url) {
-        const matcher = /http[s]?:\/\/.*\/:([a-zA-Z0-9_-]*)[\/|\?|#]?.*/;
+        const matcher = /:([a-zA-Z0-9_-]+)[\/?#&]?.*/;
         const extractArr = url.match(matcher);
         if (extractArr.length > 1) {
             return extractArr[1];


### PR DESCRIPTION
This allows the config.json to use URLs like:
* `//restool-sample-app.herokuapp.com/api/contacts/:id`
* `/api/contacts/:id`
