### PR TITLE
Support non-root deployments

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { CommonModule } from '@angular/common';
+import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { AppComponent } from './app.component';
 import { ToastrModule } from 'toastr-ng2';
 import { ConfigurationService } from './services/configuraion.service';
@@ -30,6 +30,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
     ToastrModule.forRoot()
   ],
   providers: [
+    { provide: APP_BASE_HREF, useValue: window.location.pathname },
     { provide: 'ConfigurationService', useClass: ConfigurationService },
     { provide: 'RequestsService', useClass: RequestsService },
     { provide: 'DataPathUtils', useClass: DataPathUtils },

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>RESTool</title>
-  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <script src="https://use.fontawesome.com/f0c780364a.js"></script>


### PR DESCRIPTION
This allows the build to be hosted in folders other than `/`. In my case, I want to host it in a folder like `/product/config/`.

`ng serve` still works at http://localhost:4200/.