### PR TITLE
Add optional errorMessageDataPath to config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The name of your app.
 ##### `pages` (array)
 A list of pages in your app, each page will be presented as a separated tab, and will have his own methods and properties.
 
+##### `errorMessageDataPath` (string, or array of strings)
+The path within an error response object to look for an error message. If multiple are provided, each will be tried in order until a message is found.
+
 #### Pages
 
 Each 'page' is an object. And could have the following properties:

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -112,8 +112,7 @@ export class RequestsService {
         }
       } catch {}
       return `${error.status} - ${error.statusText || ''} ${error}`;
-    } else {
-      return error.message ? error.message : error.toString();
     }
+    return error.message ? error.message : error.toString();
   }
 }

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -1,37 +1,52 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Http, Response, Headers } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
+import { ConfigurationService } from './configuraion.service';
+import { DataPathUtils } from '../utils/dataPath.utils';
 
 @Injectable()
 export class RequestsService {
+  private errorMessageDataPaths: string[] = [];
 
-  constructor(public http: Http) {}
+  constructor(public http: Http,
+              @Inject("DataPathUtils") private readonly dataPathUtils: DataPathUtils,
+              @Inject("ConfigurationService") configurationService: ConfigurationService) {
+    configurationService.getConfiguration().subscribe(configuration => {
+      if (configuration.errorMessageDataPath) {
+        if (Array.isArray(configuration.errorMessageDataPath)) {
+          this.errorMessageDataPaths = configuration.errorMessageDataPath
+        } else {
+          this.errorMessageDataPaths = [configuration.errorMessageDataPath];
+        }
+      }
+    });
+  }
 
   public get(url, headers = null, queryParams = null) {
     return this.http.get(this.buildUrl(url, queryParams), { headers: this.buildHeaders(headers) })
       .map(this.extractData)
-      .catch(this.handleError);
+      .catch(error => this.handleError(error));
   }
 
   public post(url, data, headers = null) {
     return this.http.post(url, data, { headers: this.buildHeaders(headers) })
       .map(this.extractData)
-      .catch(this.handleError);
+      .catch(error => this.handleError(error));
   }
 
   public put(url, data, headers = null) {
     return this.http.put(url, data, { headers: this.buildHeaders(headers) })
       .map(this.extractData)
-      .catch(this.handleError);
+      .catch(error => this.handleError(error));
   }
 
   public delete(url, headers = null) {
     return this.http.delete(url, { headers: this.buildHeaders(headers) })
       .map(this.extractData)
-      .catch(this.handleError);
+      .catch(error => this.handleError(error));
   }
 
   private buildHeaders(heads) {
@@ -80,16 +95,25 @@ export class RequestsService {
   }
 
   private handleError(error: Response | any) {
-    let errMsg: string;
-
-    if (error instanceof Response) {
-      // const body = error.json();
-      // const err = body.error || JSON.stringify(body);
-      errMsg = `${error.status} - ${error.statusText || ''} ${error}`;
-    } else {
-      errMsg = error.message ? error.message : error.toString();
-    }
-
+    const errMsg = this.getErrorMessage(error);
+    console.error(errMsg, error);
     return Observable.throw(errMsg);
+  }
+
+  private getErrorMessage(error: Response | any): string {
+    if (error instanceof Response) {
+      try {
+        const body = error.json();
+        for (const path of this.errorMessageDataPaths) {
+          const dataAtPath = this.dataPathUtils.extractDataFromResponse(body, path);
+          if (dataAtPath) {
+            return dataAtPath;
+          }
+        }
+      } catch {}
+      return `${error.status} - ${error.statusText || ''} ${error}`;
+    } else {
+      return error.message ? error.message : error.toString();
+    }
   }
 }

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -12,8 +12,8 @@ export class RequestsService {
   private errorMessageDataPaths: string[] = [];
 
   constructor(public http: Http,
-              @Inject("DataPathUtils") private readonly dataPathUtils: DataPathUtils,
-              @Inject("ConfigurationService") configurationService: ConfigurationService) {
+              @Inject('DataPathUtils') private readonly dataPathUtils: DataPathUtils,
+              @Inject('ConfigurationService') configurationService: ConfigurationService) {
     configurationService.getConfiguration().subscribe(configuration => {
       if (configuration.errorMessageDataPath) {
         if (Array.isArray(configuration.errorMessageDataPath)) {

--- a/src/config-sample.json
+++ b/src/config-sample.json
@@ -1,5 +1,6 @@
 {
   "name": "RESTool sample app",
+  "errorMessageDataPath": "error",
   "pages": [
     {
       "default": true,


### PR DESCRIPTION
This makes the error message a little cleaner when our API returns details as part of a DTO.

The server referenced in config-sample.json returns an error property, so you can try this out pretty easily.