### PR TITLE
Add unauthorized redirect url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ A list of pages in your app, each page will be presented as a separated tab, and
 ##### `errorMessageDataPath` (string, or array of strings)
 The path within an error response object to look for an error message. If multiple are provided, each will be tried in order until a message is found.
 
+##### `unauthorizedRedirectUrl` (string)
+Path to navigate to when the api returns a 401 (Unauthorized) error. You can use `:returnUrl` to pass a return location. For example: `"/login/myLoginPage?return=:returnUrl"`
+
 #### Pages
 
 Each 'page' is an object. And could have the following properties:

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -80,21 +80,25 @@ export class RequestsService {
       return url;
     }
 
-    let urlWithParams = `${url}?`;
+    let outputUrl = url;
     const params = [];
 
     for (let param of queryParams) {
       if (param.name) {
         let urlParamName = `:${param.name}`;
-        if (urlWithParams.indexOf(urlParamName) >= 0){
-          urlWithParams = urlWithParams.replace(urlParamName, param.value);
+        if (outputUrl.indexOf(urlParamName) >= 0){
+          outputUrl = outputUrl.replace(urlParamName, param.value);
         } else {
           params.push(`${param.name}=${param.value || ''}`);
         }
       }
     }
 
-    return urlWithParams + params.join('&');
+    if (params.length) {
+      const firstSeparator = url.indexOf('?') >= 0 ? '&' : '?';
+      return outputUrl + firstSeparator + params.join('&');
+    }
+    return outputUrl;
   }
 
   private handleError(error: Response | any) {

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -10,6 +10,7 @@ import { DataPathUtils } from '../utils/dataPath.utils';
 @Injectable()
 export class RequestsService {
   private errorMessageDataPaths: string[] = [];
+  private unauthorizedRedirectUrl: string;
 
   constructor(public http: Http,
               @Inject('DataPathUtils') private readonly dataPathUtils: DataPathUtils,
@@ -22,6 +23,8 @@ export class RequestsService {
           this.errorMessageDataPaths = [configuration.errorMessageDataPath];
         }
       }
+
+      this.unauthorizedRedirectUrl = configuration.unauthorizedRedirectUrl;
     });
   }
 
@@ -95,6 +98,14 @@ export class RequestsService {
   }
 
   private handleError(error: Response | any) {
+    if (error instanceof Response && error.status === 401 && this.unauthorizedRedirectUrl) {
+      const loginUrl = this.buildUrl(this.unauthorizedRedirectUrl, [
+        {name: 'returnUrl', value: encodeURIComponent(document.location.href)}
+      ]);
+      document.location.href = loginUrl;
+      return;
+    }
+
     const errMsg = this.getErrorMessage(error);
     console.error(errMsg, error);
     return Observable.throw(errMsg);

--- a/src/app/services/requests.service.ts
+++ b/src/app/services/requests.service.ts
@@ -88,7 +88,7 @@ export class RequestsService {
         let urlParamName = `:${param.name}`;
         if (outputUrl.indexOf(urlParamName) >= 0){
           outputUrl = outputUrl.replace(urlParamName, param.value);
-        } else {
+        } else if (!param.urlReplaceOnly) {
           params.push(`${param.name}=${param.value || ''}`);
         }
       }
@@ -104,7 +104,7 @@ export class RequestsService {
   private handleError(error: Response | any) {
     if (error instanceof Response && error.status === 401 && this.unauthorizedRedirectUrl) {
       const loginUrl = this.buildUrl(this.unauthorizedRedirectUrl, [
-        {name: 'returnUrl', value: encodeURIComponent(document.location.href)}
+        {name: 'returnUrl', value: encodeURIComponent(document.location.href), urlReplaceOnly: true}
       ]);
       document.location.href = loginUrl;
       return;


### PR DESCRIPTION
Here's a new feature that lets you redirect a user to an external site when they are not authenticated for the API they're calling.

I didn't want the return url to be required, and need to support hard-coded query parameters in the url, so I've also enhanced the `buildUrl` function a bit too.