### PR TITLE
Add data-driven select box for query parameters and post / put pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,44 +114,7 @@ An array of query param objects you want to add to your GET request.
 
 If your URL includes the name of the parameter, it will be used as part of the path rathen than as a query param. For example if your url is ``/api/contact/234/address`` you might make a paramter called ``contactId`` then set the URL as follows: ``/api/contact/:contactId/address``.
 
-#### Query Params
-
-Each query param item is an object and could have the following properties:
-
-###### ``name`` (string)
-The key / name of the parameter that should be sent.
-
-###### ``value`` (string)
-A default value.
-
-###### ``label`` (string)
-Query params will be editable in RESTool UI. This is the label the user will see in the form.
-
-###### ``type`` (string)
-In order to render the query params form, we allow you to add the "type" field where you could define the type of the field.
-Available options:
- 
-``text`` - A simple text input (if "type" is not defined, text will be the default).
-``hidden`` - Set to true if you want the query param to be sent but not to be editable.
-``boolean`` - This will render a checkbox.
-``number`` - A simple number input box that supports positive and negative integers.
-``encode`` - If you want the value to be encoded before being sent, use this type.
-``select`` - This will render a select box with predefined options.
-
-###### ``options`` (array)
-Add the `options` field if you chose a `select` as a type. This field should contain an array of options to be displayed in the select box.
-
-For example:
-
-```
-queryParams: {
-  name: 'heroes',
-  label: 'Select your hero',
-  type: 'select',
-  options: ['Spiderman', 'Batman', { display: 'Ironman', value: '324'}]
-}
-```
-
+Each query param item is an object. See [Input fields](#input-fields)
 
 ##### `display` (object)
 RESTool is going to present the data somehow. This is the object that defines how. It contains the following properties:
@@ -201,16 +164,13 @@ The properties a "get single" request could have are `url`, `dataPath`, `request
 The list of fields you want us to send as the body of the request.
 Each one is an object and could have the following properties:
 
-#### Fields
+#### Input fields
 
-###### `name` (string)
-The name of the field to be sent.
+###### ``name`` (string)
+The name of the field/parameter to be sent.
 
-###### `type` (string | 'text', 'array')
-The type of the field (will change the UI in the form accordingly).
-
-###### `label` (string)
-A label that describes the field. Will be presented as a label in the editor form.
+###### ``label`` (string)
+A label that describes the field. This is the label the user will see in the form.
 
 ###### `dataPath` (string)
 Use this field to let us know what is the path to set to the field value. For example, if the body of the request looks like below:
@@ -228,8 +188,40 @@ Use this field to let us know what is the path to set to the field value. For ex
 
 So the field name will be `url`, the type will be `text`, and the data path will be `details.thumbnail`.
 
+For POST and PUT pages only.
+
+###### ``type`` (string)
+Use the "type" field to define the type of the field.
+Available options:
+
+* ``text`` - A simple text input (if "type" is not defined, text will be the default).
+* ``encode`` - If you want the value to be encoded before being sent, use this type. GET All page only.
+* ``number`` - A simple number input box that supports positive and negative integers.
+* ``boolean`` - This will render a checkbox.
+* ``select`` - This will render a select box. See [options property](#options-array)
+* ``array`` - Enter multiple values. POST and PUT page only.
+* ``hidden`` - Set to true if you want the value to be sent but not to be editable.
+
+###### ``options`` (array)
+Add the `options` field if you chose a `select` as a type. This field should contain an array of options to be displayed in the select box.
+
+For example:
+
+```
+queryParams: {
+  name: 'heroes',
+  label: 'Select your hero',
+  type: 'select',
+  options: ['Spiderman', 'Batman', { display: 'Ironman', value: '324'}]
+}
+```
+
 ###### `arrayType` (string | 'text', 'object')
-For 'array' field type, you should specify another property called `arrayType` so we'll how to present & send the data in the POST and PUT forms.
+For 'array' field type, you should specify another property called `arrayType` so we'll how to present & send the data in the POST and PUT pages.
+
+###### ``value`` (string)
+A default value. For GET All page only.
+
 
 ## Build
 When you're feeling your project is ready, just run `ng build -prod` to build the project. The build artifacts will be stored in the `dist/` directory.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Available options:
 * ``encode`` - If you want the value to be encoded before being sent, use this type. GET All page only.
 * ``number`` - A simple number input box that supports positive and negative integers.
 * ``boolean`` - This will render a checkbox.
-* ``select`` - This will render a select box. See [options](#options-array) and [optionsSource](#optionssource-object) properties
+* ``select`` - This will render a select box. See [options](#options-array) and [optionSource](#optionsource-object) properties
 * ``array`` - Enter multiple values. POST and PUT page only.
 * ``hidden`` - Set to true if you want the value to be sent but not to be editable.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Available options:
 * ``encode`` - If you want the value to be encoded before being sent, use this type. GET All page only.
 * ``number`` - A simple number input box that supports positive and negative integers.
 * ``boolean`` - This will render a checkbox.
-* ``select`` - This will render a select box. See [options property](#options-array)
+* ``select`` - This will render a select box. See [options](#options-array) and [optionsSource](#optionssource-object) properties
 * ``array`` - Enter multiple values. POST and PUT page only.
 * ``hidden`` - Set to true if you want the value to be sent but not to be editable.
 
@@ -213,6 +213,31 @@ queryParams: {
   label: 'Select your hero',
   type: 'select',
   options: ['Spiderman', 'Batman', { display: 'Ironman', value: '324'}]
+}
+```
+
+###### ``optionSource`` (object)
+Use the `optionSource` field to load options for a select box from a REST service. If this is used with `options`, the items from `options` will be added to the select box before those fetched from the api.
+
+You can use the following properties on the `optionSource` object:
+* `url` - url to fetch data from
+* `dataPath` - let us know where we should take the data from
+* `displayPath` - property of the object to take the display value from
+* `valuePath` - property of the object to take the option value from
+
+For example:
+
+```
+fields: {
+  name: 'bestFriend',
+  label: 'Best Friend',
+  type: 'select',
+  optionSource: {
+    url: '//restool-sample-app.herokuapp.com/api/contacts',
+    dataPath: null,
+    displayPath: 'name',
+    valuePath: 'id'
+  }
 }
 ```
 

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -1,4 +1,6 @@
-<label *ngIf="labelVisible">{{label}}</label>
+<label>
+  {{labelVisible ? label : ''}}
+</label>
 
 <span [ngSwitch]="field.type" [formGroup]="form">
   <ng-template [ngSwitchCase]="'hidden'">
@@ -15,5 +17,18 @@
   </ng-template>
   <ng-template [ngSwitchCase]="'array'">
     <textarea placeholder="{{field.label}}" [formControlName]="fieldName"></textarea>
+  </ng-template>
+  <ng-template [ngSwitchCase]="'select'">
+    <select [formControlName]="fieldName">
+      <option value="">-- Select --</option>
+      <option *ngFor="let option of (field.options || [])"
+              value="{{formatSelectOption(option).value}}">{{formatSelectOption(option).display}}</option>
+    </select>
+  </ng-template>
+  <ng-template [ngSwitchCase]="'boolean'">
+    <label class="pure-checkbox">
+      <input type="checkbox" [formControlName]="fieldName"/>
+      {{label}}
+    </label>
   </ng-template>
 </span>

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -21,7 +21,7 @@
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName">
       <option value="">-- Select --</option>
-      <option *ngFor="let option of (field.options || [])"
+      <option *ngFor="let option of combinedOptions"
               value="{{formatSelectOption(option).value}}">{{formatSelectOption(option).display}}</option>
     </select>
   </ng-template>

--- a/src/app/components/input/field-input.component.ts
+++ b/src/app/components/input/field-input.component.ts
@@ -20,10 +20,27 @@ export class FieldInputComponent {
   }
 
   get labelVisible(): boolean {
-    return this.field.type !== 'hidden';
+    return this.field.type !== 'hidden' && this.field.type !== 'boolean';
   }
 
   get label(): string {
     return this.field.label || this.field.name;
+  }
+
+  public formatSelectOption(option: any){
+    let result:any = {
+      display: '',
+      value: ''
+    };
+
+    if (typeof(option) === 'string') {
+      result.display = option;
+      result.value = option;
+    } else {
+      result.display = option.display;
+      result.value = option.value;
+    }
+
+    return result;
   }
 }

--- a/src/app/components/input/field-input.component.ts
+++ b/src/app/components/input/field-input.component.ts
@@ -1,5 +1,13 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { RequestsService } from '../../services/requests.service';
+import { OptionSource, RequestHeaders } from '../../services/config.model';
+import { ToastrService } from 'ngx-toastr';
+
+export interface SelectOption {
+  display: string;
+  value: string;
+}
 
 @Component({
   selector: 'field-input',
@@ -7,10 +15,28 @@ import { FormGroup } from '@angular/forms';
   templateUrl: './field-input.component.html',
   styleUrls: ['./field-input.component.scss']
 })
-export class FieldInputComponent {
+export class FieldInputComponent implements OnInit {
   @Input() field: any;
 
   @Input() form: FormGroup;
+
+  @Input() requestHeaders?: RequestHeaders;
+
+  combinedOptions: any[] = [];
+
+  constructor(@Inject('RequestsService') private readonly requestsService: RequestsService,
+              @Inject('DataPathUtils') private readonly dataPathUtils,
+              private readonly toastrService: ToastrService) {
+  }
+
+  ngOnInit(): void {
+    if (this.field.type === 'select') {
+      this.combinedOptions = this.field.options || [];
+      if (this.field.optionSource) {
+        this.fetchOptionsFromSource(this.field.optionSource);
+      }
+    }
+  }
 
   get fieldName(): string {
     if (!this.field.dataPath) {
@@ -27,13 +53,13 @@ export class FieldInputComponent {
     return this.field.label || this.field.name;
   }
 
-  public formatSelectOption(option: any){
-    let result:any = {
+  public formatSelectOption(option: any): SelectOption {
+    let result: any = {
       display: '',
       value: ''
     };
 
-    if (typeof(option) === 'string') {
+    if (typeof (option) === 'string') {
       result.display = option;
       result.value = option;
     } else {
@@ -42,5 +68,22 @@ export class FieldInputComponent {
     }
 
     return result;
+  }
+
+  private fetchOptionsFromSource(optionSource: OptionSource) {
+    const requestHeaders = optionSource.requestHeaders || this.requestHeaders || {};
+
+    this.requestsService.get(optionSource.url, requestHeaders).subscribe(result => {
+      const data = this.dataPathUtils.extractDataFromResponse(result, optionSource.dataPath);
+      const rows: SelectOption[] = data.map(row => ({
+        display: this.dataPathUtils.extractDataFromResponse(row, null, optionSource.displayPath),
+        value: this.dataPathUtils.extractDataFromResponse(row, null, optionSource.valuePath)
+      }));
+
+      this.combinedOptions = [
+        ...(this.field.options || []),
+        ...rows
+      ];
+    }, error => this.toastrService.error(error, `Error loading options for ${this.label}`));
   }
 }

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -1,6 +1,6 @@
 <div class="pure-g header">
-  <div class="description pure-u-1-2" *ngIf="pageData && pageData.description">
-    {{pageData.description}}
+  <div class="description pure-u-1-2">
+    {{pageData ? pageData.description : ''}}
   </div>
   <div class="create pure-u-1-2">
     <button class="pure-button button-success button-xlarge" *ngIf="pageData && pageData.methods && pageData.methods.post" (click)="onClickNew()">+ Add Item</button>

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -9,27 +9,7 @@
 
 <form *ngIf="queryParams.length" class="pure-form pure-form-stacked" [formGroup]="myForm" (ngSubmit)="getResults()">
   <fieldset>
-    <div class="pure-control-group" *ngFor="let queryParam of queryParams" [ngSwitch]="queryParam.type">
-      <ng-template [ngSwitchCase]="'hidden'" ngSwitchDefault>
-        <input type="hidden" [formControlName]="queryParam.name" value="{{queryParam.value || ''}}" />
-      </ng-template>
-      <ng-template [ngSwitchCase]="'boolean'">
-        <label class="pure-checkbox">
-          <input type="checkbox" [formControlName]="queryParam.name" [ngModel]="queryParam.value" /> {{queryParam.label || queryParam.name}}
-        </label>
-      </ng-template>
-      <ng-template [ngSwitchCase]="'select'">
-        <label>{{queryParam.label || queryParam.name}}</label>
-        <select [formControlName]="queryParam.name" [ngModel]="queryParam.value">
-          <option value="">-- Select --</option>
-          <option *ngFor="let option of (queryParam.options || [])" value="{{formatSelectOption(option).value}}">{{formatSelectOption(option).display}}</option>
-        </select>
-      </ng-template>
-      <div *ngSwitchDefault>
-        <label for="name">{{queryParam.label || queryParam.name}}</label>
-        <input id="name" type="text" placeholder="{{queryParam.label}}" [formControlName]="queryParam.name"/>
-      </div>
-    </div>
+    <field-input [field]="field" [form]="myForm" *ngFor="let field of queryParams" class="pure-control-group"></field-input>
 
     <div class="pure-controls">
       <button type="submit" class="pure-button pure-button-primary">Submit</button>

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -9,7 +9,10 @@
 
 <form *ngIf="queryParams.length" class="pure-form pure-form-stacked" [formGroup]="myForm" (ngSubmit)="getResults()">
   <fieldset>
-    <field-input [field]="field" [form]="myForm" *ngFor="let field of queryParams" class="pure-control-group"></field-input>
+    <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
+                 *ngFor="let field of queryParams"
+                 class="pure-control-group">
+    </field-input>
 
     <div class="pure-controls">
       <button type="submit" class="pure-button pure-button-primary">Submit</button>

--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Inject, Output, EventEmitter, ViewChild } from '@angular/core';
+import {Component, Input, Inject, Output, EventEmitter } from '@angular/core';
 import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 
@@ -47,23 +47,6 @@ export class GetComponent {
       state: 'put',
       data: row
     });
-  }
-
-  public formatSelectOption(option: any){
-    let result:any = {
-      display: '',
-      value: ''
-    };
-    
-    if (typeof(option) === 'string') {
-      result.display = option;
-      result.value = option;
-    } else {
-      result.display = option.display;
-      result.value = option.value;
-    }
-
-    return result;
   }
 
   public firstRequest() {

--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input, Inject, Output, EventEmitter } from '@angular/core';
 import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
+import { RequestHeaders } from '../../../services/config.model';
 
 @Component({
   selector: 'app-get',
@@ -70,12 +71,15 @@ export class GetComponent {
     this.getRequest();
   }
 
+  get requestHeaders(): RequestHeaders {
+    return this.activeGetRequest.requestHeaders || this.pageData.requestHeaders || {};;
+  }
+
   private getRequest(queryParams = null) {
     if (this.activeGetRequest) {
       this.loading = true;
 
-      const requestHeaders = this.activeGetRequest.requestHeaders || this.pageData.requestHeaders || {};
-      this.requestsService.get(this.activeGetRequest.url, requestHeaders, queryParams || this.queryParams).subscribe(data => {
+      this.requestsService.get(this.activeGetRequest.url, this.requestHeaders, queryParams || this.queryParams).subscribe(data => {
         this.loading = false;
         this.data = this.dataPathUtils.extractDataFromResponse(data, this.activeGetRequest.dataPath);
 

--- a/src/app/components/main-view/post/post.component.html
+++ b/src/app/components/main-view/post/post.component.html
@@ -5,7 +5,10 @@
       <p *ngIf="!fields || !fields.length">No fields defined.</p>
       <form *ngIf="fields && fields.length" class="pure-form pure-form-aligned" [formGroup]="myForm" (ngSubmit)="submit($event);">
         <fieldset>
-          <field-input [field]="field" [form]="myForm" *ngFor="let field of fields" class="pure-control-group"></field-input>
+          <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
+                       *ngFor="let field of fields"
+                       class="pure-control-group">
+          </field-input>
           <div class="center">
             <button type="submit" class="pure-button pure-button-primary button-large">Submit</button>
           </div>

--- a/src/app/components/main-view/post/post.component.ts
+++ b/src/app/components/main-view/post/post.component.ts
@@ -3,6 +3,7 @@ import {FormGroup, FormControl, FormBuilder, FormArray} from '@angular/forms';
 import {DataPathUtils} from '../../../utils/dataPath.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
+import { RequestHeaders } from '../../../services/config.model';
 
 @Component({
   selector: 'post-dialog',
@@ -86,12 +87,14 @@ export class PostComponent implements OnInit {
     this.request(data);
   }
 
+  get requestHeaders(): RequestHeaders {
+    return this.methodData.requestHeaders || this.pageData.requestHeaders || {};
+  }
+
   private request(data = {}) {
     this.loading = true;
 
     console.log('Making post request with data', data);
-
-    const requestHeaders = this.methodData.requestHeaders || this.pageData.requestHeaders || {};
 
     let actualMethod = this.requestsService.post.bind(this.requestsService);
     const actualMethodType = this.methodData.actualMethod;
@@ -99,7 +102,7 @@ export class PostComponent implements OnInit {
       actualMethod = this.requestsService[actualMethodType].bind(this.requestsService);
     }
 
-    actualMethod(this.methodData.url, data, requestHeaders).subscribe(data => {
+    actualMethod(this.methodData.url, data, this.requestHeaders).subscribe(data => {
       this.loading = false;
       this.toastrService.success('Successfully created an item', 'Success');
       this.close(true);

--- a/src/app/components/main-view/put/put.component.html
+++ b/src/app/components/main-view/put/put.component.html
@@ -5,7 +5,10 @@
       <p *ngIf="!fields || !fields.length">No fields defined.</p>
       <form *ngIf="fields && fields.length" class="pure-form pure-form-aligned" [formGroup]="myForm" (ngSubmit)="submit($event);">
         <fieldset>
-          <field-input [field]="field" [form]="myForm" *ngFor="let field of fields" class="pure-control-group"></field-input>
+          <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
+                       *ngFor="let field of fields"
+                       class="pure-control-group">
+          </field-input>
           <div class="center">
             <button type="submit" class="pure-button pure-button-primary button-large">Submit</button>
           </div>

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -3,6 +3,7 @@ import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
 import {DataPathUtils} from '../../../utils/dataPath.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
+import { RequestHeaders } from '../../../services/config.model';
 
 @Component({
   selector: 'put-dialog',
@@ -92,12 +93,14 @@ export class PutComponent implements OnInit  {
     this.request(data);
   }
 
+  get requestHeaders(): RequestHeaders {
+    return this.methodData.requestHeaders || this.pageData.requestHeaders || {};
+  }
+
   private request(data = {}) {
     this.loading = true;
 
     console.log('Making put request with data', data);
-
-    const requestHeaders = this.methodData.requestHeaders || this.pageData.requestHeaders || {};
 
     let actualMethod = this.requestsService.put.bind(this.requestsService);
     const actualMethodType = this.methodData.actualMethod;
@@ -109,7 +112,7 @@ export class PutComponent implements OnInit  {
     const dataPath = this.methodData.dataPath;
     putUrl = this.urlUtils.getParsedUrl(putUrl, this.rowData, dataPath);
 
-    actualMethod(putUrl, data, requestHeaders).subscribe(data => {
+    actualMethod(putUrl, data, this.requestHeaders).subscribe(data => {
       this.loading = false;
       this.toastrService.success('Successfully updated item', 'Success');
       this.close(true);

--- a/src/app/services/config.model.ts
+++ b/src/app/services/config.model.ts
@@ -1,0 +1,11 @@
+export interface RequestHeaders {
+  [key: string]: string;
+}
+
+export interface OptionSource {
+  url: string;
+  dataPath: string;
+  valuePath: string;
+  displayPath: string;
+  requestHeaders?: RequestHeaders
+}


### PR DESCRIPTION
I switched the query parameters on the get page to use the same input-field component as the post and put pages, allowing more logic to be shared across all the different views. This brought select and checkbox types to the post/put fields. I also added the `optionSource` property so the select boxes can pull their data dynamically from an arbitrary api.

I updated the readme for both changes. Because the code is shared between the two, I wanted both queryParams and fields to be documented in only one place. There are a couple options that only work for one or the other, so I had to add notes for those.

I've also fixed a minor layout issue when a page doesn't have a description.