### PR TITLE
Fix error: Observable.of not defined

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { APP_BASE_HREF, CommonModule } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { AppComponent } from './app.component';
 import { ToastrModule } from 'ngx-toastr';
 import { ConfigurationService } from './services/configuraion.service';
@@ -30,7 +30,6 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
     ToastrModule.forRoot()
   ],
   providers: [
-    { provide: APP_BASE_HREF, useValue: window.location.pathname },
     { provide: 'ConfigurationService', useClass: ConfigurationService },
     { provide: 'RequestsService', useClass: RequestsService },
     { provide: 'DataPathUtils', useClass: DataPathUtils },

--- a/src/app/components/main-view/main-view.component.ts
+++ b/src/app/components/main-view/main-view.component.ts
@@ -1,8 +1,9 @@
 import {Component, OnInit, Inject, ViewChild} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-import {Observable} from 'rxjs/Rx';
+import {of} from 'rxjs';
 import {GetComponent} from './get/get.component';
+
 @Component({
   selector: 'app-main-view',
   templateUrl: './main-view.component.html',
@@ -66,13 +67,13 @@ export class MainViewComponent implements OnInit {
 
   private getRowData(defaultData = {}) {
     if (!this.pageData.methods.getSingle) {
-      return Observable.of(defaultData);
+      return of(defaultData);
     }
 
     const getMethod = this.pageData.methods.getSingle;
     let getUrl = getMethod.url;
     if (!getUrl) {
-      return Observable.of(defaultData);
+      return of(defaultData);
     }
 
     const dataPath = getMethod.dataPath;

--- a/src/app/services/configuraion.service.ts
+++ b/src/app/services/configuraion.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {Http} from '@angular/http';
 import 'rxjs/add/operator/map';
-import {Observable} from 'rxjs/Observable';
+import {of} from 'rxjs';
 import 'rxjs/add/observable/of';
 
 @Injectable()
@@ -18,7 +18,7 @@ export class ConfigurationService {
 
     getConfiguration() {
         if (this.configuration) {
-            return Observable.of(this.configuration);
+            return of(this.configuration);
         } else {
             this.configStream.subscribe(config => {
                 this.configuration = this.checkLocalOrRemoteConfiguration(config);


### PR DESCRIPTION
I found another small issue after the upgrade. It shows up if you navigate to the app directly without a `#/page` specified.

I also discovered that the `APP_BASE_HREF` registration isn't necessary any more, so I'm dropping that too.