### PR TITLE
Prevent logging of data sent/received from API in production builds

### DIFF
--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -2,6 +2,7 @@ import {Component, Input, Inject, Output, EventEmitter } from '@angular/core';
 import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { RequestHeaders } from '../../../services/config.model';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-get',
@@ -83,7 +84,9 @@ export class GetComponent {
         this.loading = false;
         this.data = this.dataPathUtils.extractDataFromResponse(data, this.activeGetRequest.dataPath);
 
-        console.log('Got data after dataPath: ', this.data);
+        if (environment.logApiData) {
+          console.log('Got data after dataPath: ', this.data);
+        }
       }, error => {
         this.loading = false;
         this.toastrService.error(error, 'Error');
@@ -164,7 +167,9 @@ export class GetComponent {
     const dataPath = deleteMethod.dataPath;
     deleteUrl = this.urlUtils.getParsedUrl(deleteUrl, row, dataPath);
 
-    console.log('Delete url', deleteUrl);
+    if (environment.logApiData) {
+      console.log('Delete url', deleteUrl);
+    }
 
     let actualMethod = this.requestsService.delete.bind(this.requestsService);
     const actualMethodType = this.pageData.methods.delete.actualMethod;

--- a/src/app/components/main-view/main-view.component.ts
+++ b/src/app/components/main-view/main-view.component.ts
@@ -3,6 +3,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import {of} from 'rxjs';
 import {GetComponent} from './get/get.component';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-main-view',
@@ -79,7 +80,9 @@ export class MainViewComponent implements OnInit {
     const dataPath = getMethod.dataPath;
     getUrl = this.urlUtils.getParsedUrl(getUrl, defaultData, dataPath);
 
-    console.log('Get single url', getUrl);
+    if (environment.logApiData) {
+      console.log('Get single url', getUrl);
+    }
 
     let actualMethod = this.requestsService.get.bind(this.requestsService);
     const actualMethodType = this.pageData.methods.getSingle.actualMethod;
@@ -95,7 +98,9 @@ export class MainViewComponent implements OnInit {
     switch (this.popupState) {
       case 'put':
         this.getRowData(e.data || {}).subscribe((res) => {
-          console.log('Single item data', res);
+          if (environment.logApiData) {
+            console.log('Single item data', res);
+          }
           this.selectedRow = res;
         }, (e) => {
           console.error(e);

--- a/src/app/components/main-view/post/post.component.ts
+++ b/src/app/components/main-view/post/post.component.ts
@@ -4,6 +4,7 @@ import {DataPathUtils} from '../../../utils/dataPath.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { RequestHeaders } from '../../../services/config.model';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'post-dialog',
@@ -94,7 +95,9 @@ export class PostComponent implements OnInit {
   private request(data = {}) {
     this.loading = true;
 
-    console.log('Making post request with data', data);
+    if (environment.logApiData) {
+      console.log('Making post request with data', data);
+    }
 
     let actualMethod = this.requestsService.post.bind(this.requestsService);
     const actualMethodType = this.methodData.actualMethod;

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -4,6 +4,7 @@ import {DataPathUtils} from '../../../utils/dataPath.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { RequestHeaders } from '../../../services/config.model';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'put-dialog',
@@ -100,7 +101,9 @@ export class PutComponent implements OnInit  {
   private request(data = {}) {
     this.loading = true;
 
-    console.log('Making put request with data', data);
+    if (environment.logApiData) {
+      console.log('Making put request with data', data);
+    }
 
     let actualMethod = this.requestsService.put.bind(this.requestsService);
     const actualMethodType = this.methodData.actualMethod;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  logApiData: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,5 +4,6 @@
 // The list of which env maps to which file can be found in `angular-cli.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  logApiData: true
 };


### PR DESCRIPTION
With some of our larger data sets, quite a bit of data is being dumped to the console window. This change keeps the functionality for development builds, and makes it easy for someone to add back when making a production build (just edit environment.prod.ts).