### PR TITLE
support URLs with 0..* parameters, and encode values

### DIFF
--- a/src/app/utils/url.utils.ts
+++ b/src/app/utils/url.utils.ts
@@ -1,40 +1,39 @@
-import {Injectable, Inject} from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 
 @Injectable()
 export class UrlUtils {
 
-    constructor(@Inject('DataPathUtils') private dataPathUtils) {
+  constructor(@Inject('DataPathUtils') private dataPathUtils) {
+  }
+
+  public urlIsClearOfParams(url) {
+    if (url.indexOf(':') >= 0) {
+      return false;
     }
+    return url;
+  }
 
-    public urlIsClearOfParams(url) {
-        if (url.indexOf(':') >= 0) {
-            return false;
-        }
-        return url;
+  public extractIdFieldName(url) {
+    const matcher = /:([a-zA-Z0-9_-]+)[\/?#&]?.*/;
+    const extractArr = url.match(matcher);
+    if (extractArr && extractArr.length > 1) {
+      return extractArr[1];
     }
+    return null;
+  }
 
-    public extractIdFieldName(url) {
-        const matcher = /:([a-zA-Z0-9_-]+)[\/?#&]?.*/;
-        const extractArr = url.match(matcher);
-        if (extractArr.length > 1) {
-            return extractArr[1];
-        }
-        return null;
+  public getUrlWithReplacedId(url, fieldName, fieldValue) {
+    return url.replace(':' + fieldName, fieldValue);
+  }
+
+  public getParsedUrl(url, data, dataPath) {
+    let fieldName = this.extractIdFieldName(url);
+    while (fieldName !== null) {
+      let fieldValue = this.dataPathUtils.getFieldValueInPath(fieldName, dataPath, data);
+      fieldValue = (fieldValue !== null) ? encodeURIComponent(fieldValue) : '';
+      url = this.getUrlWithReplacedId(url, fieldName, fieldValue);
+      fieldName = this.extractIdFieldName(url);
     }
-
-    public getUrlWithReplacedId(url, fieldName, fieldValue) {
-        return url.replace(':' + fieldName, fieldValue);
-    }
-
-    public getParsedUrl(url, data, dataPath) {
-        const fieldName = this.extractIdFieldName(url);
-        const fieldValue = this.dataPathUtils.getFieldValueInPath(fieldName, dataPath, data);
-        if (fieldValue) {
-            url = this.getUrlWithReplacedId(url, fieldName, fieldValue);
-            return url;
-        }
-    }
-
-
-
+    return url;
+  }
 }


### PR DESCRIPTION
This allows for a put URL like `/house/:houseNumber/apartment/:apartmentNumber`, with as many `:variable` parameters as a user wants. It also allows for 0. I'm also encoding the values in case they're not simple database ids.

The whitespace was a little funky in the file, so I've touched that too. Hopefully that doesn't make it too hard to review the change.