### PR TITLE
Allow for dynamic parameters in option source url

### DIFF
--- a/src/app/components/main-view/post/post.component.html
+++ b/src/app/components/main-view/post/post.component.html
@@ -6,6 +6,7 @@
       <form *ngIf="fields && fields.length" class="pure-form pure-form-aligned" [formGroup]="myForm" (ngSubmit)="submit($event);">
         <fieldset>
           <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
+                       [workingRowData]="workingRowData" [methodDataPath]="methodData.dataPath"
                        *ngFor="let field of fields"
                        class="pure-control-group">
           </field-input>

--- a/src/app/components/main-view/post/post.component.ts
+++ b/src/app/components/main-view/post/post.component.ts
@@ -42,6 +42,8 @@ export class PostComponent implements OnInit {
 
   methodData: any = {};
 
+  workingRowData: any;
+
   constructor(@Inject('RequestsService') private requestsService,
               @Inject('DataPathUtils') private dataPathUtils,
               private _fb: FormBuilder,
@@ -62,7 +64,10 @@ export class PostComponent implements OnInit {
     } catch (e) {
       this.fields = [];
     }
+
     this.myForm = this._fb.group(this.buildFormFields(this.fields));
+    this.myForm.valueChanges.subscribe(() => this.updateWorkingRowData());
+    this.updateWorkingRowData();
   }
 
   private buildFormFields(fields = []) {
@@ -81,11 +86,14 @@ export class PostComponent implements OnInit {
     return obj;
   }
 
+  private updateWorkingRowData() {
+    const fields = this.buildFields();
+    this.workingRowData = this.dataPathUtils.extractModelFromFields(fields);
+  }
+
   public submit(e: Event) {
     e.preventDefault();
-    const fields = this.buildFields();
-    const data = this.dataPathUtils.extractModelFromFields(fields);
-    this.request(data);
+    this.request(this.workingRowData);
   }
 
   get requestHeaders(): RequestHeaders {

--- a/src/app/components/main-view/put/put.component.html
+++ b/src/app/components/main-view/put/put.component.html
@@ -6,6 +6,7 @@
       <form *ngIf="fields && fields.length" class="pure-form pure-form-aligned" [formGroup]="myForm" (ngSubmit)="submit($event);">
         <fieldset>
           <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
+                       [workingRowData]="workingRowData" [methodDataPath]="methodData.dataPath"
                        *ngFor="let field of fields"
                        class="pure-control-group">
           </field-input>

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -43,6 +43,8 @@ export class PutComponent implements OnInit  {
 
   methodData: any = {};
 
+  workingRowData: any;
+
   constructor(@Inject('RequestsService') private requestsService,
               @Inject('DataPathUtils') private dataPathUtils,
               @Inject('UrlUtils') private urlUtils,
@@ -65,6 +67,9 @@ export class PutComponent implements OnInit  {
       this.fields = [];
     }
     this.myForm = this._fb.group(this.buildFormFields());
+
+    this.myForm.valueChanges.subscribe(() => this.updateWorkingRowData());
+    this.updateWorkingRowData();
   }
 
   private buildFormFields() {
@@ -87,11 +92,14 @@ export class PutComponent implements OnInit  {
     return obj;
   }
 
+  private updateWorkingRowData() {
+    const fields = this.buildFields();
+    this.workingRowData = this.dataPathUtils.extractModelFromFields(fields);
+  }
+
   public submit(e: Event) {
     e.preventDefault();
-    const fields = this.buildFields();
-    const data = this.dataPathUtils.extractModelFromFields(fields);
-    this.request(data);
+    this.request(this.workingRowData);
   }
 
   get requestHeaders(): RequestHeaders {


### PR DESCRIPTION
This allows the URL for an on option source to contain parameters, and those parameters can come from other fields on the same form. This helps when you have a reference to hierarchical data and need to filter the options in a select box.