### PR TITLE
Multiple inputs for array type

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ fields: {
 }
 ```
 
-###### `arrayType` (string | 'text', 'object')
+###### `arrayType` (string)
 For 'array' field type, you should specify another property called `arrayType` so we'll how to present & send the data in the POST and PUT pages.
 
 ###### ``default`` (string)

--- a/src/app/components/input/array-input.component.html
+++ b/src/app/components/input/array-input.component.html
@@ -1,0 +1,12 @@
+<form [formGroup]="arrayForm" class="pure-form">
+  <div *ngFor="let itemField of arrayFields" class="array-item">
+    <field-input [field]="itemField" [form]="arrayForm" [requestHeaders]="requestHeaders"
+                 [workingRowData]="workingRowData" [methodDataPath]="methodDataPath">
+    </field-input>
+    <div class="pure-button-group">
+      <button class="pure-button" [ngClass]="{hide: !canDeleteItem(itemField)}" (click)="deleteItem(itemField)">
+        <i class="fa fa-times" aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/app/components/input/array-input.component.scss
+++ b/src/app/components/input/array-input.component.scss
@@ -1,0 +1,17 @@
+@import "../../../styles/purecss";
+
+.array-item {
+  .pure-button-group {
+    padding-left: 6px;
+    display: inline-block;
+    vertical-align: middle;
+
+    .hide {
+      display: none;
+    }
+  }
+
+  & div {
+    padding: 1px 0;
+  }
+}

--- a/src/app/components/input/array-input.component.ts
+++ b/src/app/components/input/array-input.component.ts
@@ -1,0 +1,130 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { RequestHeaders } from '../../services/config.model';
+
+@Component({
+  selector: 'array-input',
+  templateUrl: './array-input.component.html',
+  styleUrls: ['./array-input.component.scss']
+})
+export class ArrayInputComponent implements OnInit {
+  @Input() field: any;
+  @Input() form: FormGroup;
+  @Input() requestHeaders?: RequestHeaders;
+  @Input() workingRowData: any;
+  @Input() methodDataPath: any;
+
+  arrayFields: any[];
+
+  arrayForm: FormGroup;
+
+  private nextFieldIndex = 0;
+  private emptyItemName?: string;
+
+  ngOnInit(): void {
+    this.initForm();
+    this.arrayForm.valueChanges.subscribe(() => this.updateArrayValue())
+
+    if (!this.field.readonly) {
+      this.arrayForm.valueChanges.subscribe(() => this.addEmptyItemIfNecessary());
+    }
+  }
+
+  private initForm() {
+    const formControls = {};
+    const arrayFields = [];
+    let index = 0;
+    for (const itemValue of this.arrayValue) {
+      const itemField = this.createField();
+      arrayFields.push(itemField);
+      formControls[itemField.name] = new FormControl(itemValue);
+    }
+    this.arrayForm = new FormGroup(formControls);
+    this.arrayFields = arrayFields;
+    if (!this.field.readonly) {
+      this.addEmptyItem();
+    }
+  }
+
+  private updateArrayValue() {
+    const newValue = [];
+    const formControls = this.arrayForm.controls;
+    for (let i = 0; i <= this.nextFieldIndex; i++) {
+      const name = this.getControlNameForIndex(i);
+      if (formControls.hasOwnProperty(name)) {
+        let value = formControls[name].value;
+        if (typeof value === 'string' && value.length === 0) {
+          value = null;
+        }
+        if (value != null) {
+          newValue.push(value);
+        }
+      }
+    }
+    this.arrayValue = newValue;
+  }
+
+  private get arrayFieldName(): string {
+    if (!this.field.dataPath) {
+      return this.field.name;
+    }
+    return `${this.field.dataPath}.${this.field.name}`;
+  }
+
+  private get arrayValue(): any {
+    return this.form.value[this.arrayFieldName] || [];
+  }
+
+  private set arrayValue(newValue: any) {
+    this.form.controls[this.arrayFieldName].setValue(newValue);
+  }
+
+  private createField() {
+    const name = this.getControlNameForIndex(this.nextFieldIndex++);
+    return {
+      ...this.field,
+      arrayChild: true,
+      name: name,
+      dataPath: null,
+      type: this.field.arrayType,
+      default: null
+    };
+  }
+
+  private getControlNameForIndex(index: number): string {
+    return `${index}`;
+  }
+
+  deleteItem(field: any) {
+    const index = this.arrayFields.indexOf(field);
+    if (index >= 0) {
+      this.arrayFields.splice(index, 1);
+      this.arrayForm.removeControl(field.name);
+    }
+  }
+
+  private addEmptyItemIfNecessary() {
+    if (this.fieldHasValue(this.emptyItemName)) {
+      this.addEmptyItem();
+    }
+  }
+
+  fieldHasValue(name: string): boolean {
+    const formControl = this.arrayForm.controls[name];
+    if (!formControl) {
+      return false;
+    }
+    return (typeof formControl.value === 'string' && formControl.value.length > 0) || formControl.value != null;
+  }
+
+  private addEmptyItem() {
+    const field = this.createField();
+    this.emptyItemName = field.name;
+    this.arrayForm.addControl(field.name, new FormControl(null));
+    this.arrayFields.push(field);
+  }
+
+  canDeleteItem(itemField: any): boolean {
+    return !this.field.readonly && this.fieldHasValue(itemField.name);
+  }
+}

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -4,19 +4,19 @@
 
 <span [ngSwitch]="field.type" [formGroup]="form">
   <ng-template [ngSwitchCase]="'hidden'">
-    <input type="hidden" placeholder="{{field.label}}" [formControlName]="fieldName"/>
+    <input type="hidden" [formControlName]="fieldName"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'text'" ngSwitchDefault>
-    <input type="text" placeholder="{{field.label}}" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+    <input type="text" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'integer'">
-    <input type="number" placeholder="{{field.label}}" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+    <input type="number" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'number'">
-    <input type="number" placeholder="{{field.label}}" [formControlName]="fieldName" step="any" [required]="field.required" [readOnly]="field.readonly"/>
+    <input type="number" [placeholder]="placeholder" [formControlName]="fieldName" step="any" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'email'">
-    <input type="email" placeholder="{{field.label}}" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+    <input type="email" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName" [required]="field.required">

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -1,4 +1,4 @@
-<label [ngClass]="{'required': field.required}">
+<label [ngClass]="{'required': field.required}" *ngIf="!field.arrayChild">
   {{labelVisible ? label : ''}}
 </label>
 
@@ -18,9 +18,6 @@
   <ng-template [ngSwitchCase]="'email'">
     <input type="email" placeholder="{{field.label}}" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
-  <ng-template [ngSwitchCase]="'array'">
-    <textarea placeholder="{{field.label}}" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"></textarea>
-  </ng-template>
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName" [required]="field.required">
       <option value="">-- Select --</option>
@@ -33,5 +30,10 @@
       <input type="checkbox" [formControlName]="fieldName" [readOnly]="field.readonly"/>
       {{label}}
     </label>
+  </ng-template>
+  <ng-template [ngSwitchCase]="'array'">
+    <array-input [field]="field" [form]="form" [requestHeaders]="requestHeaders"
+                 [workingRowData]="workingRowData" [methodDataPath]="methodDataPath">
+    </array-input>
   </ng-template>
 </span>

--- a/src/app/components/input/field-input.component.ts
+++ b/src/app/components/input/field-input.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, OnChanges, OnInit, SimpleChanges, ViewEncapsulation } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { RequestsService } from '../../services/requests.service';
 import { OptionSource, RequestHeaders } from '../../services/config.model';
 import { ToastrService } from 'ngx-toastr';
@@ -41,19 +41,21 @@ export class FieldInputComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.workingRowData$.next(this.workingRowData);
 
-    if (this.field.type === 'select') {
-      this.combinedOptions = this.field.options || [];
-      if (this.field.optionSource) {
-        const url = this.field.optionSource.url;
-        if (this.urlUtils.urlIsClearOfParams(url)) {
-          this.fetchOptionsFromSource(url);
-        } else {
-          this.workingRowData$.pipe(
-            map(rowData => this.urlUtils.getParsedUrl(url, rowData, this.methodDataPath)),
-            distinctUntilChanged())
-            .subscribe(resolvedUrl => this.fetchOptionsFromSource(resolvedUrl));
+    switch (this.field.type) {
+      case 'select':
+        this.combinedOptions = this.field.options || [];
+        if (this.field.optionSource) {
+          const url = this.field.optionSource.url;
+          if (this.urlUtils.urlIsClearOfParams(url)) {
+            this.fetchOptionsFromSource(url);
+          } else {
+            this.workingRowData$.pipe(
+              map(rowData => this.urlUtils.getParsedUrl(url, rowData, this.methodDataPath)),
+              distinctUntilChanged())
+              .subscribe(resolvedUrl => this.fetchOptionsFromSource(resolvedUrl));
+          }
         }
-      }
+        break;
     }
   }
 

--- a/src/app/components/input/field-input.component.ts
+++ b/src/app/components/input/field-input.component.ts
@@ -80,6 +80,13 @@ export class FieldInputComponent implements OnInit, OnChanges {
     return this.field.label || this.field.name;
   }
 
+  get placeholder(): string {
+    if (this.field.readonly) {
+      return '';
+    }
+    return this.label;
+  }
+
   public formatSelectOption(option: any): SelectOption {
     let result: any = {
       display: '',

--- a/src/app/components/main-view/main-view.module.ts
+++ b/src/app/components/main-view/main-view.module.ts
@@ -3,17 +3,18 @@ import { NgModule } from '@angular/core';
 import { MainViewComponent } from "./main-view.component";
 import { Routing } from "./main-view.routes";
 import { LoaderComponent } from "../loader/loader.component";
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 import { GetComponent } from './get/get.component';
 import { PutComponent } from './put/put.component';
 import { PostComponent } from './post/post.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FieldInputComponent } from '../input/field-input.component';
+import { ArrayInputComponent } from '../input/array-input.component';
 
 @NgModule({
   imports: [CommonModule, Routing, ReactiveFormsModule, BrowserAnimationsModule],
   exports: [],
-  declarations: [MainViewComponent, LoaderComponent, GetComponent, PutComponent, PostComponent, FieldInputComponent],
+  declarations: [MainViewComponent, LoaderComponent, GetComponent, PutComponent, PostComponent, FieldInputComponent, ArrayInputComponent],
   providers: [],
 })
 export class MainViewModule { }

--- a/src/app/components/main-view/post/post.component.ts
+++ b/src/app/components/main-view/post/post.component.ts
@@ -77,10 +77,7 @@ export class PostComponent implements OnInit {
     }
     for (const field of fields) {
       const fieldName = field.dataPath ? `${field.dataPath}.${field.name}` : field.name;
-      let value = field.default === undefined ? '' : field.default;
-      if (field.type === 'array') {
-        value = JSON.stringify(value || []);
-      }
+      const value = field.default === undefined ? '' : field.default;
       obj[fieldName] = [value];
     }
     return obj;

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -78,15 +78,8 @@ export class PutComponent implements OnInit  {
       return obj;
     }
     for (const field of this.fields) {
-      let value = this.dataPathUtils.getFieldValueInPath(field.name, field.dataPath, this.rowData)
+      const value = this.dataPathUtils.getFieldValueInPath(field.name, field.dataPath, this.rowData)
       const fieldName = field.dataPath ? `${field.dataPath}.${field.name}` : field.name;
-      if (field.type === 'array') {
-        // value = value.map((i) => field.arrayType === 'object' ? JSON.stringify(i) : i);
-        if (!value) {
-          value = [];
-        }
-        value = JSON.stringify(value, null, '\t');
-      }
       obj[fieldName] = new FormControl(value === undefined ? '' : value);
     }
     return obj;
@@ -139,12 +132,8 @@ export class PutComponent implements OnInit  {
       const paramArr = param.split('.');
       const dataPath = paramArr.slice(0, -1).join('.');
       let value = this.myForm.controls[param].value;
-      if (typeof value === 'string') {
-        if (value.length === 0) {
-          value = null;
-        } else if (value.indexOf('[') === 0 && value.indexOf(']') === value.length - 1) {
-          value = JSON.parse(value);
-        }
+      if (typeof value === 'string' && value.length === 0) {
+        value = null;
       }
       fields.push({
         name: paramArr[paramArr.length - 1],


### PR DESCRIPTION
This makes the array type render as multiple controls, with the control for the type specified in `arrayType`.

I didn't spend a lot of effort making it pretty, but I don't think it looks bad:
![image](https://user-images.githubusercontent.com/7407231/51289909-f106ae80-19b6-11e9-9e2d-34cd1052350c.png)

I've also included a fix for the readonly feature: it now hides the placeholder text for readonly fields.