### PR TITLE
Issue-37 - Added a simple type='colorbox' display field

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ One or more paths to properties in the result object to sort the list by.
 ###### `name` (string)
 The name of the field that contains the value in the results.
 
-###### `type` (string | 'text', 'url', 'image')
+###### `type` (string | 'text', 'url', 'image', 'colorbox')
 The type of the returning value.
+
+A `colorbox` type will render a #RRGGBB hex string as an 80 x 20 pixel colored rectangle, overlaid with the hex color string.
 
 ###### `label` (string)
 A label that describes the field. Will be presented as table headers in RESTool.
@@ -202,6 +204,8 @@ Available options:
 * ``integer`` - A text box for positive and negative integers.
 * ``number`` - A text box for positive and negative floating point numbers.
 * ``boolean`` - This will render a checkbox.
+* ``email`` - A text box for [an email address](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email). Falls back to a simple text input on unsupported browsers.
+* ``color`` - A [color selector](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) yielding #RRGGBB hex value strings. Falls back to a simple text input on unsupported browsers.
 * ``select`` - This will render a select box. See [options](#options-array) and [optionSource](#optionsource-object) properties
 * ``array`` - Enter multiple values. POST and PUT page only.
 * ``hidden`` - Set to true if you want the value to be sent but not to be editable.

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -18,6 +18,9 @@
   <ng-template [ngSwitchCase]="'email'">
     <input type="email" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
+  <ng-template [ngSwitchCase]="'color'">
+    <input type="color" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+  </ng-template>
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName" [required]="field.required">
       <option value="">-- Select --</option>

--- a/src/app/components/input/field-input.component.scss
+++ b/src/app/components/input/field-input.component.scss
@@ -1,1 +1,5 @@
 @import "../../../styles/purecss";
+
+input[type="color"] {
+	height: 40px;
+}

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -46,6 +46,13 @@
           <ng-template [ngSwitchCase]="'image'">
             <div class="thumb" [ngStyle]="{backgroundImage: 'url(' + dataPathUtils.extractDataFromResponse(row, field.dataPath, field.name) + ')'}"></div>
           </ng-template>
+          <ng-template [ngSwitchCase]="'colorbox'">
+            <div class="colorbox"
+                [style.backgroundColor]="dataPathUtils.extractDataFromResponse(row, field.dataPath, field.name)"
+                [style.color]="xorHexColor(dataPathUtils.extractDataFromResponse(row, field.dataPath, field.name))">
+                {{dataPathUtils.extractDataFromResponse(row, field.dataPath, field.name)}}
+            </div>
+          </ng-template>
         </div>
       </td>
       <td *ngIf="showActions()" [ngStyle]="{textAlign: 'center'}">

--- a/src/app/components/main-view/get/get.component.scss
+++ b/src/app/components/main-view/get/get.component.scss
@@ -70,3 +70,9 @@
   background: no-repeat center center;
   background-size: cover;
 }
+
+.colorbox {
+  width: 80px;
+  height: 20px;
+  padding: 0 1em 0;
+}

--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -194,5 +194,9 @@ export class GetComponent {
       this.toastrService.error(error, 'Error');
     });
   }
+  
+  protected xorHexColor(hexColor) {
+    return '#' + (0xffffff ^ parseInt(hexColor.substring(1), 16)).toString(16)
+  }
 
 }


### PR DESCRIPTION
This just shows a 80px x 20px rectangle bound to the data value, which can be any support HTML color spec (named color, hex string, rrgb(), or hsl() expression.