### PR TITLE
Feature/issue 44 multipart file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Available options:
 * ``color`` - A [color selector](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) yielding #RRGGBB hex value strings. Falls back to a simple text input on unsupported browsers.
 * ``select`` - This will render a select box. See [options](#options-array) and [optionSource](#optionsource-object) properties
 * ``array`` - Enter multiple values. POST and PUT page only.
-* ``file`` - A file-input form element, to upload files as `Content-Type: multipart/form-data`. All non-file form inputs will be sent as individual string values.
+* ``file`` - A file-input form element, to upload files as `Content-Type: multipart/form-data`. All non-file form inputs will be sent as individual string values. The current implementation supports only one file input per form.
 * ``hidden`` - Set to true if you want the value to be sent but not to be editable.
 
 ###### ``options`` (array)
@@ -263,6 +263,20 @@ If true, a field will be marked as required on PUT and POST pages.
 
 ###### ``readonly`` (boolean)
 If true, a field will be displayed, but not editable. It's data will still be added to the PUT request.
+
+###### ``accept`` (string)
+An optional setting for `type="file"` POST and PUT inputs. When set, the file input's [accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) property will perform file type filtering when browsing for files.
+
+For example:
+
+```
+"post": {
+  "url": "/images",
+  "fields": [
+	{"name": "File", "label": "Upload your image", "type": "file", "required": true, "accept": ".png,.jpeg,image/*"}
+  ]
+},
+```
 
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Available options:
 * ``color`` - A [color selector](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) yielding #RRGGBB hex value strings. Falls back to a simple text input on unsupported browsers.
 * ``select`` - This will render a select box. See [options](#options-array) and [optionSource](#optionsource-object) properties
 * ``array`` - Enter multiple values. POST and PUT page only.
+* ``file`` - A file-input form element, to upload files as `Content-Type: multipart/form-data`. All non-file form inputs will be sent as individual string values.
 * ``hidden`` - Set to true if you want the value to be sent but not to be editable.
 
 ###### ``options`` (array)

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { MainViewModule } from './components/main-view/main-view.module';
 import { NavigationComponent } from './components/navigation/navigation.component';
 import { Routing } from './app.routes';
 import {DataPathUtils} from './utils/dataPath.utils';
+import {MultipartFormUtils} from './utils/multipartForm.utils';
 import {UrlUtils} from './utils/url.utils';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
@@ -33,6 +34,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
     { provide: 'ConfigurationService', useClass: ConfigurationService },
     { provide: 'RequestsService', useClass: RequestsService },
     { provide: 'DataPathUtils', useClass: DataPathUtils },
+    { provide: 'MultipartFormUtils', useClass: MultipartFormUtils },
     { provide: 'UrlUtils', useClass: UrlUtils }
   ],
   bootstrap: [AppComponent]

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -21,6 +21,9 @@
   <ng-template [ngSwitchCase]="'color'">
     <input type="color" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
+  <ng-template [ngSwitchCase]="'file'">
+    <input type="file" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+  </ng-template>
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName" [required]="field.required">
       <option value="">-- Select --</option>

--- a/src/app/components/input/field-input.component.html
+++ b/src/app/components/input/field-input.component.html
@@ -22,7 +22,7 @@
     <input type="color" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'file'">
-    <input type="file" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly"/>
+    <input type="file" [placeholder]="placeholder" [formControlName]="fieldName" [required]="field.required" [readOnly]="field.readonly" [accept]="field.accept"/>
   </ng-template>
   <ng-template [ngSwitchCase]="'select'">
     <select [formControlName]="fieldName" [required]="field.required">

--- a/src/app/components/main-view/post/post.component.ts
+++ b/src/app/components/main-view/post/post.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit, Input, Inject, Output, EventEmitter} from '@angular/core';
 import {FormGroup, FormControl, FormBuilder, FormArray} from '@angular/forms';
 import {DataPathUtils} from '../../../utils/dataPath.utils';
+import {MultipartFormUtils} from '../../../utils/multipartForm.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { RequestHeaders } from '../../../services/config.model';
@@ -46,6 +47,7 @@ export class PostComponent implements OnInit {
 
   constructor(@Inject('RequestsService') private requestsService,
               @Inject('DataPathUtils') private dataPathUtils,
+              @Inject('MultipartFormUtils') private multipartFormUtils,
               private _fb: FormBuilder,
               private toastrService: ToastrService) { }
 
@@ -102,6 +104,10 @@ export class PostComponent implements OnInit {
 
     if (environment.logApiData) {
       console.log('Making post request with data', data);
+    }
+
+    if (this.multipartFormUtils.isMultipartForm(this.fields)) {
+      data = this.multipartFormUtils.extractMultipartFormData(this.fields, this.myForm);
     }
 
     let actualMethod = this.requestsService.post.bind(this.requestsService);

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit, Input, Inject, Output, EventEmitter} from '@angular/core';
 import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
 import {DataPathUtils} from '../../../utils/dataPath.utils';
+import {MultipartFormUtils} from '../../../utils/multipartForm.utils';
 import { ToastrService } from 'ngx-toastr';
 import { trigger, state, style, animate, transition } from '@angular/animations';
 import { RequestHeaders } from '../../../services/config.model';
@@ -47,6 +48,7 @@ export class PutComponent implements OnInit  {
 
   constructor(@Inject('RequestsService') private requestsService,
               @Inject('DataPathUtils') private dataPathUtils,
+              @Inject('MultipartFormUtils') private multipartFormUtils,
               @Inject('UrlUtils') private urlUtils,
               private toastrService: ToastrService,
               private _fb: FormBuilder) { }
@@ -104,6 +106,10 @@ export class PutComponent implements OnInit  {
 
     if (environment.logApiData) {
       console.log('Making put request with data', data);
+    }
+
+    if (this.multipartFormUtils.isMultipartForm(this.fields)) {
+      data = this.multipartFormUtils.extractMultipartFormData(this.fields, this.myForm);
     }
 
     let actualMethod = this.requestsService.put.bind(this.requestsService);

--- a/src/app/utils/multipartForm.utils.ts
+++ b/src/app/utils/multipartForm.utils.ts
@@ -1,0 +1,50 @@
+import {Injectable} from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Injectable()
+export class MultipartFormUtils {
+
+  constructor() {
+  }
+
+  private isMultipartForm(fields: any[]): boolean {
+
+    for (const fieldIndex in fields)
+    {
+      let field = fields[fieldIndex];
+
+      if (field.type == "file")
+        return true;
+    }
+
+    return false;
+  }
+
+  private extractMultipartFormData(fields: any[], formGroup: FormGroup): FormData {
+    let formData = new FormData();
+
+    for (const fieldIndex in fields)
+    {
+      let field = fields[fieldIndex];
+      let value = formGroup.controls[field.name].value;
+
+      if (typeof value === 'string' && value.length ===0) {
+        value = null;
+      }
+
+      if (field.type == "file") {
+        // TODO: Support more than 1 file input per form.
+        let fileInput : HTMLInputElement = document.querySelector('input[type="file"]');
+
+        if (fileInput.files.length > 0) {
+          let firstFile = fileInput.files[0];
+          formData.append(field.name, firstFile, firstFile.name);
+        }
+      } else if (value != null && value != undefined) {   
+        formData.append(field.name, value);
+      }
+    }
+
+    return formData;
+  }
+}


### PR DESCRIPTION
This change will make allow a `type="file"` form input, and use a POST/PUT request body of multipart form data instead os JSON, to allow file uploads.

An optional field `accept` property can be set to limit the file types in the platform-specific file browsing dialog.

It is currently limited to one file input per form.

![image](https://user-images.githubusercontent.com/54773/52595493-dd5a3680-2e02-11e9-9b4c-6fd6ca3a6197.png)

![image](https://user-images.githubusercontent.com/54773/52595561-0084e600-2e03-11e9-8622-2473746f4d0c.png)



