### PR TITLE
Allow simple client-side text filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ RESTool is going to present the data somehow. This is the object that defines ho
 ###### `type` (string | 'table')
 How would you like to present the data (at the moment we only support table view).
 
-###### `fields` (array)
-The list of fields you want to present in your main view. Each one is an object and could have the following properties:
-
 ###### `sortBy` (string | array)
 One or more paths to properties in the result object to sort the list by.
+
+###### `fields` (array)
+The list of fields you want to present in your main view. Each one is an object and could have the following properties:
 
 #### Display fields
 
@@ -159,6 +159,9 @@ Use this field to let us know what is the path to get to the field value. For ex
 ```
 
 And you want to present the `numberOfChildrens` field in the display view, your data path for this field is `details`, and the `name` should be `numberOfChildrens`.
+
+###### `filterable` (bool)
+Set to `true` to enable a text control to do simple client-side filtering by values of this field. Can be specified for multiple fields.
 
 #### GET SINGLE (getSingle)
 We'll use this type of get request to get a single item. By default, if you won't config this request, when editing an item we'll take the row data from the original "get all" request.

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -7,22 +7,28 @@
   </div>
 </div>
 
-<form *ngIf="queryParams.length" class="pure-form pure-form-stacked" [formGroup]="myForm" (ngSubmit)="getResults()">
-  <fieldset>
-    <field-input [field]="field" [form]="myForm" [requestHeaders]="requestHeaders"
-                 *ngFor="let field of queryParams"
-                 class="pure-control-group">
-    </field-input>
-
-    <div class="pure-controls">
-      <button type="submit" class="pure-button pure-button-primary">Submit</button>
-    </div>
-  </fieldset>
-</form>
-
 <app-loader [loading]="loading" [size]="'small'"></app-loader>
 
 <div *ngIf="!loading">
+
+  <form *ngIf="queryParams.length" class="pure-form pure-form-stacked" [formGroup]="queryForm" (ngSubmit)="getResults()">
+    <fieldset>
+      <field-input [field]="field" [form]="queryForm" [requestHeaders]="requestHeaders"
+                  *ngFor="let field of queryParams"
+                  class="pure-control-group">
+      </field-input>
+
+      <div class="pure-controls">
+        <button type="submit" class="pure-button pure-button-primary">Submit</button>
+      </div>
+    </fieldset>
+  </form>
+
+  <form *ngIf="filterableFields.length" class="pure-form form-group filter-form" #filterForm="ngForm">
+    <fieldset>
+      <input type="text" placeholder="Filter" class="form-control pure-input-1" [(ngModel)]="filterText" name="filterText"/>
+    </fieldset>
+  </form>
 
   <table class="pure-table pure-table-horizontal">
     <thead>
@@ -32,7 +38,7 @@
     </tr>
     </thead>
     <tbody>
-    <tr *ngFor="let row of data">
+    <tr *ngFor="let row of (data | rowFilter:filterableFields:filterText)">
       <td *ngFor="let field of fields">
         <div [ngSwitch]="field.type">
           <ng-template [ngSwitchCase]="'text'" ngSwitchDefault>

--- a/src/app/components/main-view/get/get.component.scss
+++ b/src/app/components/main-view/get/get.component.scss
@@ -87,3 +87,7 @@
   border-radius: 4px;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
+
+.filter-form {
+  width: 20em;
+}

--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, Inject, Output, EventEmitter } from '@angular/core';
-import {FormGroup, FormControl, FormBuilder} from '@angular/forms';
+import { FormGroup, FormControl, FormBuilder } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
 import { RequestHeaders } from '../../../services/config.model';
 import { environment } from '../../../../environments/environment';
@@ -20,13 +20,17 @@ export class GetComponent {
 
   data: Array<Object> = [];
 
-  myForm: FormGroup = this._fb.group(this.getQueryParamsObj());
+  queryForm: FormGroup = this._fb.group(this.getQueryParamsObj());
 
   activeGetRequest: any = {};
 
   fields: any = [];
 
+  filterableFields: any = [];
+
   queryParams: any = [];
+
+  filterText: string = "";
 
   constructor(@Inject('RequestsService') private requestsService,
               @Inject('DataPathUtils') private dataPathUtils,
@@ -64,10 +68,12 @@ export class GetComponent {
 
     this.activeGetRequest = this.pageData.methods.getAll;
     this.fields = this.getDisplayFields(this.activeGetRequest);
+    this.filterableFields = this.getFilterableFields(this.fields);
     this.queryParams = this.activeGetRequest.queryParams || [];
+    this.filterText = "";
 
     if (this.queryParams.length) {
-      this.myForm = this._fb.group(this.getQueryParamsObj());
+      this.queryForm = this._fb.group(this.getQueryParamsObj());
     }
 
     this.getRequest();
@@ -102,9 +108,9 @@ export class GetComponent {
 
   public getResults() {
     const queryParams = [];
-    for (const param in this.myForm.controls) {
+    for (const param in this.queryForm.controls) {
       const type = this.getQueryParamType(param);
-      let value = this.myForm.controls[param].value || '';
+      let value = this.queryForm.controls[param].value || '';
 
       if (type === 'encode') {
         value = encodeURIComponent(value);
@@ -153,6 +159,10 @@ export class GetComponent {
       return [];
     }
     return params.display.fields;
+  }
+
+  private getFilterableFields(fields: Array<any>): Array<any> {
+    return fields.filter(field => field.filterable);
   }
 
   protected showActions() {

--- a/src/app/components/main-view/main-view.module.ts
+++ b/src/app/components/main-view/main-view.module.ts
@@ -3,18 +3,19 @@ import { NgModule } from '@angular/core';
 import { MainViewComponent } from "./main-view.component";
 import { Routing } from "./main-view.routes";
 import { LoaderComponent } from "../loader/loader.component";
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { GetComponent } from './get/get.component';
 import { PutComponent } from './put/put.component';
 import { PostComponent } from './post/post.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FieldInputComponent } from '../input/field-input.component';
 import { ArrayInputComponent } from '../input/array-input.component';
+import { RowFilterPipe } from './row-filter.pipe';
 
 @NgModule({
-  imports: [CommonModule, Routing, ReactiveFormsModule, BrowserAnimationsModule],
+  imports: [CommonModule, Routing, FormsModule, ReactiveFormsModule, BrowserAnimationsModule],
   exports: [],
-  declarations: [MainViewComponent, LoaderComponent, GetComponent, PutComponent, PostComponent, FieldInputComponent, ArrayInputComponent],
+  declarations: [MainViewComponent, LoaderComponent, GetComponent, PutComponent, PostComponent, FieldInputComponent, ArrayInputComponent, RowFilterPipe],
   providers: [],
 })
 export class MainViewModule { }

--- a/src/app/components/main-view/row-filter.pipe.ts
+++ b/src/app/components/main-view/row-filter.pipe.ts
@@ -1,0 +1,24 @@
+import { Inject, Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({name: 'rowFilter'})
+export class RowFilterPipe implements PipeTransform {
+  constructor(@Inject('DataPathUtils') private readonly dataPathUtils) {
+  }
+
+  public transform(rows: Array<any>, fields: Array<any>, filterText: string): Array<any> {
+    if (!filterText || !fields || !rows) {
+        return rows;
+    }
+
+    let upperFilterText = filterText.toUpperCase();
+    return rows.filter(row => {
+      for (let field of fields) {
+        let value = this.dataPathUtils.extractDataFromResponse(row, field.dataPath, field.name);
+        if (value && value.toString().toUpperCase().indexOf(upperFilterText) !== -1) {
+          return true;
+        }
+      }
+      return false;
+    });
+  }
+}

--- a/src/config-sample.json
+++ b/src/config-sample.json
@@ -30,23 +30,27 @@
               {
                 "name": "id",
                 "type": "text",
-                "label": "ID"
+                "label": "ID",
+                "filterable": true
               },
               {
                 "name": "name",
                 "type": "text",
-                "label": "Name"
+                "label": "Name",
+                "filterable": true
               },
               {
                 "name": "email",
                 "type": "text",
-                "label": "Email"
+                "label": "Email",
+                "filterable": true
               },
               {
                 "name": "work",
                 "type": "text",
                 "label": "Phone #",
-                "dataPath": "phone"
+                "dataPath": "phone",
+                "filterable": true
               }
             ],
             "sortBy": ["name"]


### PR DESCRIPTION
This PR allows very simple client-side text filtering by certain fields. Any fields configured with `"filterable": true` are included (by calling .toString on the value). The control is shown on a page if at least 1 field is filterable.

I am very inexperienced with CSS so happy for any suggestions to tidy up the layout.

Example:

![image](https://user-images.githubusercontent.com/1489637/53293064-e5f72900-3781-11e9-8544-aae3b1dfa5a9.png)
