### PR TITLE
Added extra-methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ testem.log
 #System Files
 .DS_Store
 Thumbs.db
+
+/dist/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ A list of all methods which are available in your RESTfull API. Available method
 * put
 * post
 
+##### `extraMethods` (array)
+A list of extra (non RESTfull) endpoints available in your ~RESTfull~ API. Specifically `extraMethods` is a list of PUT or POST method objects. For example this could enable an endpoint like: ``PUT http://website.com/users/:id/disable``
+
+> These use the same format as the method objects defined below.
+
+> The default HTTP method used is PUT but this can be overidden using the `actualMethod` parameter. 
+
+> If `extraMethods` is not empty then a drop down apears in the Edit Item dialog which allows users to select the action they want to perform.
+
 #### Methods
 
 Each method has the following common properties:

--- a/src/app/components/main-view/put/put.component.html
+++ b/src/app/components/main-view/put/put.component.html
@@ -1,5 +1,12 @@
 <div [@dialog] *ngIf="visible" class="dialog">
-  <h2>Edit Item</h2>
+  <h2 *ngIf="actionNames.length > 1">Select action:
+    <select (change)="actionSelectionOnChange($event.target.value)" [value]='actionSelection'>
+      <option *ngFor="let actionName of actionNames; let i = index" [value]="i">
+        {{actionName}}
+      </option>
+    </select>
+  </h2>
+  <h2 *ngIf="actionNames.length == 1">Edit Item</h2>
   <div class="inner">
     <div class="form_wrapper">
       <p *ngIf="!fields || !fields.length">No fields defined.</p>

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -42,6 +42,10 @@ export class PutComponent implements OnInit  {
 
   fields: Array<any> = [];
 
+  actionNames: Array<any> = [];
+
+  actionSelection: number = 0;
+
   methodData: any = {};
 
   workingRowData: any;
@@ -61,10 +65,24 @@ export class PutComponent implements OnInit  {
     this.initForm();
   }
 
+  actionSelectionOnChange(i) {
+    this.actionSelection = i;
+    this.initForm();
+  }
+
   private initForm() {
+    if(this.pageData && this.pageData.extraMethods){
+      this.actionNames = ["Edit"].concat(this.pageData.extraMethods.map( x => x.name))
+    }else{
+      this.actionNames = ["Edit"]
+    }
     try {
-      this.methodData = this.pageData.methods.put;
-      this.fields = this.pageData.methods.put.fields;
+      if(this.actionSelection == 0){
+        this.methodData = this.pageData.methods.put;
+      }else{
+        this.methodData = this.pageData.extraMethods[this.actionSelection - 1];
+      }
+      this.fields = this.methodData.fields;
     } catch (e) {
       this.fields = [];
     }

--- a/src/config-sample.json
+++ b/src/config-sample.json
@@ -167,7 +167,46 @@
         "delete": {
           "url": "https://restool-sample-app.herokuapp.com/api/contacts/:id"
         }
-      }
+      },
+      "extraMethods":[{
+          "name":"Send Fan Mail",
+          "url": "https://restool-sample-app.herokuapp.com/api/contacts/:id/send-fan-mail",
+          "actualMethod": "post",
+          "fields": [
+            {
+              "name": "id",
+              "type": "text",
+              "label": "Contact ID",
+              "readonly": true
+            },
+            {
+              "name": "title",
+              "type": "text",
+              "label": "Email Title",
+              "required": true
+            },
+            {
+              "name": "body",
+              "type": "text",
+              "label": "Email Body",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name":"Disable Contact",
+          "url": "https://restool-sample-app.herokuapp.com/api/contacts/:id/disable",
+          "actualMethod": "post",
+          "fields": [
+            {
+              "name": "id",
+              "type": "text",
+              "label": "Contact ID",
+              "readonly": true
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Sadly a lot APIs in the wild are only 90% RESTful. Most people cannot resist the urge to add in a cheeky extra action endpoint. I came across one of these APIs so I made this tweak.

# Changes
- Add new array attribute on page called `extraMethods` which is a list of PUT methods. 
- If set a dropdown now appears on the Edit Item dialog to allow the user to select the action they want to perform (endpoint they want to call).
- README and sample-config.json have been updated with instructions and examples

These allow extra endpoints to be added such as `PUT http://website.com/users/:id/disable`

![Screen Shot 2019-04-02 at 19 41 23](https://user-images.githubusercontent.com/3439407/55427664-6548fb00-557f-11e9-8fab-cada221fe2aa.png)

I rarely code front ends (thats why I am using this tool) so please feel free to change anything/everything
I appreciate this may not align with the vision for the RESTool but it is really useful for real world APIs
I would love to hear your feedback
