### PR TITLE
Added useInUrl field option

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ If true, a field will be marked as required on PUT and POST pages.
 ###### ``readonly`` (boolean)
 If true, a field will be displayed, but not editable. It's data will still be added to the PUT request.
 
+###### ``useInUrl`` (boolean)
+If true, a field can be used as a paramter in a PUT url. Otherwise only fields retreived in the original GET can be used as paramters. It's data will still be added to the PUT request body.
+
 ###### ``accept`` (string)
 An optional setting for `type="file"` POST and PUT inputs. When set, the file input's [accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) property will perform file type filtering when browsing for files.
 

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -123,7 +123,15 @@ export class PutComponent implements OnInit  {
 
     let putUrl = this.methodData.url;
     const dataPath = this.methodData.dataPath;
-    putUrl = this.urlUtils.getParsedUrl(putUrl, this.rowData, dataPath);
+
+    const extraUrlData = {};
+    this.fields.map((field) => {
+      if (field.useInUrl) {
+        extraUrlData[field.name] = data[field.name];
+      }
+    });
+
+    putUrl = this.urlUtils.getParsedUrl(putUrl, Object.assign(this.rowData, extraUrlData), dataPath);
 
     this.fields.map((field) => {
       if (field.type === 'object' || field.type === 'json') {


### PR DESCRIPTION
Currently only values retrieved in the GET of an object can be used as parameters in the URL of a PUT
# Changes
* Added `useInUrl` as boolean option on a field object in a PUT method.
* Effectively allows a user to define a value that can then be used as a parameter in the URL

No worries if you don't want this change either 😃  Could be helpful for some