### PR TITLE
Two-way bind filter text to route query param

### DIFF
--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -1,5 +1,5 @@
 <nav>
-  <a *ngFor="let page of pages" [routerLink]="page.id" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+  <a *ngFor="let page of pages" [routerLink]="page.id" routerLinkActive="active" [routerLinkActiveOptions]="{exact: false}">
     {{page.name}}
   </a>
 </nav>


### PR DESCRIPTION
Now the filter is stored in URL so that it persists after reload and filtered view can be shared with others.

Setting the nav's routerLinkActiveOptions exact to false still seems to work correctly when there are route IDs that are substrings of other IDs, e.g. 'characters' and 'characters2'.