### PR TITLE
New customActions parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ A list of all methods which are available in your RESTfull API. Available method
 * put
 * post
 
+##### `customActions` (array)
+A list of extra (non RESTfull) endpoints available in your ~RESTfull~ API. Specifically `customActions` is a list of PUT or POST method objects. For example this could enable an endpoint like: ``PUT http://website.com/users/:id/disable``
+
+> These use the same format as the method objects defined below.
+
+> The default HTTP method used is PUT but this can be overidden using the `actualMethod` parameter. 
+
+> If `customActions` is not empty then a drop down apears in the Edit Item dialog which allows users to select the action they want to perform.
+
 #### Methods
 
 Each method has the following common properties:

--- a/src/app/components/main-view/get/get.component.html
+++ b/src/app/components/main-view/get/get.component.html
@@ -69,6 +69,9 @@
           <button class="pure-button" [ngClass]="{hide: !pageData.methods.put}" (click)="onClickEdit(row)">
             <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
           </button>
+          <button class="pure-button" [ngClass]="{hide: !pageData.customActions}" (click)="onClickCustomActions(row)">
+            <i class="fa fa-cogs" aria-hidden="true"></i>
+          </button>
           <button class="pure-button" [ngClass]="{hide: !pageData.methods.delete}" (click)="delete(row)">
             <i class="fa fa-times" aria-hidden="true"></i>
           </button>

--- a/src/app/components/main-view/get/get.component.ts
+++ b/src/app/components/main-view/get/get.component.ts
@@ -91,6 +91,13 @@ export class GetComponent {
     });
   }
 
+  onClickCustomActions(row) {
+    this.stateChanged.emit({
+      state: 'customActions',
+      data: row
+    });
+  }
+
   onFilterTextChange(newValue: string, updateQueryParam: boolean = true) {
     this.filterText = newValue;
     this.filterRows();

--- a/src/app/components/main-view/main-view.component.html
+++ b/src/app/components/main-view/main-view.component.html
@@ -1,5 +1,5 @@
 <main>
   <app-get [pageData]="pageData" (stateChanged)="showPopup($event)"></app-get>
-  <put-dialog [visible]="popupState === 'put' && !loading" (stateChanged)="showPopup($event)" [(rowData)]="selectedRow" [pageData]="pageData"></put-dialog>
+  <put-dialog [visible]="popupState === 'put' || popupState === 'customActions' && !loading" (stateChanged)="showPopup($event)" [(rowData)]="selectedRow" [pageData]="pageData" [state]="popupState"></put-dialog>
   <post-dialog [visible]="popupState === 'post'" (stateChanged)="showPopup($event)" [pageData]="pageData"></post-dialog>
 </main>

--- a/src/app/components/main-view/main-view.component.ts
+++ b/src/app/components/main-view/main-view.component.ts
@@ -107,6 +107,7 @@ export class MainViewComponent implements OnInit {
     this.popupState = e.state || null;
     switch (this.popupState) {
       case 'put':
+      case 'customActions':
         this.loading = true;
         this.getRowData(e.data || {}).subscribe((res) => {
           if (environment.logApiData) {

--- a/src/app/components/main-view/put/put.component.html
+++ b/src/app/components/main-view/put/put.component.html
@@ -1,5 +1,12 @@
 <div [@dialog] *ngIf="visible" class="dialog">
-  <h2>Edit Item</h2>
+  <h2 *ngIf="customActionNames.length > 1">Select action:
+    <select (change)="customActionSelectionOnChange($event.target.value)" [value]='customActionSelection'>
+      <option *ngFor="let customAction of customActionNames; let i = index" [value]="i">
+        {{customAction}}
+      </option>
+    </select>
+  </h2>
+  <h2 *ngIf="customActionNames.length == 1">Edit Item</h2>
   <div class="inner">
     <div class="form_wrapper">
       <p *ngIf="!fields || !fields.length">No fields defined.</p>

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -28,6 +28,8 @@ export class PutComponent implements OnInit  {
 
   @Input() visible: boolean;
 
+  @Input() state: string;
+
   @Output() visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @Output() stateChanged = new EventEmitter();
@@ -41,6 +43,10 @@ export class PutComponent implements OnInit  {
   myForm: FormGroup = this._fb.group(this.buildFormFields());
 
   fields: Array<any> = [];
+
+  customActionNames: Array<any> = [];
+
+  customActionSelection: number = 0;
 
   methodData: any = {};
 
@@ -61,10 +67,21 @@ export class PutComponent implements OnInit  {
     this.initForm();
   }
 
+  customActionSelectionOnChange(i) {
+    this.customActionSelection = i;
+    this.initForm();
+  }
+
   private initForm() {
     try {
-      this.methodData = this.pageData.methods.put;
-      this.fields = this.pageData.methods.put.fields;
+      if(this.state == "customActions"){
+        this.customActionNames = this.pageData.customActions.map( x => x.name)
+        this.methodData = this.pageData.customActions[this.customActionSelection];
+      }else{
+        this.customActionNames = ["Edit"]
+        this.methodData = this.pageData.methods.put;
+      }
+      this.fields = this.methodData.fields;
     } catch (e) {
       this.fields = [];
     }

--- a/src/config-sample.json
+++ b/src/config-sample.json
@@ -351,7 +351,46 @@
         "delete": {
           "url": "/extra/:id"
         }
-      }
+      },
+      "customActions":[{
+          "name":"Send Fan Mail",
+          "url": "https://restool-sample-app.herokuapp.com/api/contacts/:id/send-fan-mail",
+          "actualMethod": "post",
+          "fields": [
+            {
+              "name": "id",
+              "type": "text",
+              "label": "Contact ID",
+              "readonly": true
+            },
+            {
+              "name": "title",
+              "type": "text",
+              "label": "Email Title",
+              "required": true
+            },
+            {
+              "name": "body",
+              "type": "text",
+              "label": "Email Body",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name":"Disable Contact",
+          "url": "https://restool-sample-app.herokuapp.com/api/contacts/:id/disable",
+          "actualMethod": "post",
+          "fields": [
+            {
+              "name": "id",
+              "type": "text",
+              "label": "Contact ID",
+              "readonly": true
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
> This PR contains is the same as https://github.com/dsternlicht/RESTool/pull/53 but has the requested changes 


Sadly a lot APIs in the wild are only 90% RESTful. Most people cannot resist the urge to add in a cheeky extra action endpoint. I came across one of these APIs so I made this tweak.

# Changes
- Add new array attribute on page called `customActions` which is a list of PUT methods. 
- If set a dropdown now appears on the Edit Item dialog to allow the user to select the action they want to perform (endpoint they want to call).
- README and sample-config.json have been updated with instructions and examples

These allow extra endpoints to be added such as `PUT http://website.com/users/:id/disable`

![RESTool_sample_app](https://user-images.githubusercontent.com/3439407/62628921-1d1e5880-b924-11e9-85e1-4890d896a079.png)

![Screen Shot 2019-08-07 at 15 03 50](https://user-images.githubusercontent.com/3439407/62629186-9b7afa80-b924-11e9-988a-3ffb6dc5de9d.png)

