### PR TITLE
Added omitFromPayload parameter on PUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,10 @@ If true, a field will be marked as required on PUT and POST pages.
 If true, a field will be displayed, but not editable. It's data will still be added to the PUT request.
 
 ###### ``useInUrl`` (boolean)
-If true, a field can be used as a paramter in a PUT url. Otherwise only fields retreived in the original GET can be used as paramters. It's data will still be added to the PUT request body.
+If true, a field can be used as a paramter in a PUT url. Otherwise only fields retreived in the original GET can be used as parameters. By default it's data will still be added to the PUT request body (unless ``omitFromPayload`` is true).
+
+###### ``omitFromPayload`` (boolean)
+If true the value will not be added to the PUT request body. This is useful if you would like to display some readonly data that should not be submitted back to the API.
 
 ###### ``accept`` (string)
 An optional setting for `type="file"` POST and PUT inputs. When set, the file input's [accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) property will perform file type filtering when browsing for files.

--- a/src/app/components/main-view/put/put.component.ts
+++ b/src/app/components/main-view/put/put.component.ts
@@ -138,6 +138,11 @@ export class PutComponent implements OnInit  {
         data[field.name] = JSON.parse(data[field.name]);
       }
     });
+    this.fields.map((field) => {
+      if (field.omitFromPayload) {
+        delete data[field.name];
+      }
+    });
 
     actualMethod(putUrl, data, this.requestHeaders).subscribe(data => {
       this.loading = false;

--- a/src/config-sample.json
+++ b/src/config-sample.json
@@ -66,6 +66,13 @@
           "actualMethod": null,
           "fields": [
             {
+                "name": "name",
+                "type": "text",
+                "label": "Name",
+                "readOnly": true,
+                "omitFromPayload": true
+            },
+            {
               "name": "location",
               "label": "Location",
               "type": "select",


### PR DESCRIPTION
# Changes
* Some APIs do not allow you to submit readOnly fields on PUT. Added `omitFromPayload` for fields that should not be added to a PUT payload.

> Not sure if this is necessary but it was helpful for an API I am using so I thought I would share