### PR TITLE
Bugfix: Restoring broken functionality for array lists

### DIFF
--- a/src/app/components/main-view/main-view.component.html
+++ b/src/app/components/main-view/main-view.component.html
@@ -1,5 +1,5 @@
 <main>
   <app-get [pageData]="pageData" (stateChanged)="showPopup($event)"></app-get>
-  <put-dialog [visible]="popupState === 'put' || popupState === 'customActions' && !loading" (stateChanged)="showPopup($event)" [(rowData)]="selectedRow" [pageData]="pageData" [state]="popupState"></put-dialog>
+  <put-dialog [visible]="(popupState === 'put' || popupState === 'customActions') && !loading" (stateChanged)="showPopup($event)" [(rowData)]="selectedRow" [pageData]="pageData" [state]="popupState"></put-dialog>
   <post-dialog [visible]="popupState === 'post'" (stateChanged)="showPopup($event)" [pageData]="pageData"></post-dialog>
 </main>


### PR DESCRIPTION
Looks like a recent feature addition broke some existing functionality.
This PR fixes the bug.

The bug prevents array lists from being displayed. Every other piece of data seems to display correctly.
With this data:
```
{
    "Results": [{
            "UniqueId": "f2bbedebaf0d43209eda8e38df780cc7",
            "Key": "Test",
            "ValueType": "PickList",
            "PickListValues": ["a", "b", "c"]
        }
    ]
}
```
and this (partial) config. Note: The revelant field is `PickListValues`:
```
        "put": {
          "url": "/AQUARIUS/Provisioning/v1/tags/:UniqueId",
          "fields": [
            {"name": "Key", "label": "Key", "type": "text", "required": true},
            {"name": "ValueType", "label": "Value Type", "type": "select", "options": [{"value": "None", "display": "None"}, {"value": "PickList", "display": "Pick List"}], "default": "None"},
            {"name": "PickListValues", "label": "Pick List Values", "type": "array", "arrayType": "string"},
            {"name": "UniqueId", "label": "Unique ID", "type": "text", "readonly": true}
          ]
        },
```

Before the bugfix:
![image](https://user-images.githubusercontent.com/6333375/66605451-fd462380-eb64-11e9-8011-beaaf61fad3f.png)

After the bugfix:
![image](https://user-images.githubusercontent.com/6333375/66605533-1f3fa600-eb65-11e9-951e-52727a8df304.png)
