### PR TITLE
Fix for data refresh when lazy-loading pagination is on

### DIFF
--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -123,8 +123,12 @@ const PageComp = ({ context }: IProps) => {
     if (refreshData === true) {
       if (pagination?.type === 'lazy-loading') {
         setItems([]);
+        const updatedParams = [...queryParams];
+        remove(updatedParams, param => ['page', 'limit'].includes(param.name));
+        setQueryParams(buildInitQueryParamsAndPaginationState(updatedParams, paginationConfig).initQueryParams);
+      } else {
+        getAllRequest();
       }
-      getAllRequest();
     }
   }
 
@@ -315,7 +319,14 @@ const PageComp = ({ context }: IProps) => {
       });
 
       if (success) {
-        getAllRequest();
+        if (pagination?.type === 'lazy-loading') {
+          setItems([]);
+          const updatedParams = [...queryParams];
+          remove(updatedParams, param => ['page', 'limit'].includes(param.name));
+          setQueryParams(buildInitQueryParamsAndPaginationState(updatedParams, paginationConfig).initQueryParams);
+        } else {
+          getAllRequest();
+        }
       }
     } catch (e) {
       toast.error(e.message);

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -121,6 +121,9 @@ const PageComp = ({ context }: IProps) => {
     setOpenedPopup(null);
 
     if (refreshData === true) {
+      if (pagination?.type === 'lazy-loading') {
+        setItems([]);
+      }
       getAllRequest();
     }
   }


### PR DESCRIPTION
Fix for data refresh when lazy-loading pagination is on after a item add/edit/delete.

Missed that one.