### PR TITLE
Feature/add html cell

### DIFF
--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -428,7 +428,8 @@
             "url",
             "image",
             "colorbox",
-            "boolean"
+            "boolean",
+            "html"
           ],
           "description": "This will help RESTool to render the main view.\ntext -  will parse the value as a text\nurl -  will render an anchor element with a clickable link\nimage -  will render an image from the url\ncolorbox -  will render a #RRGGBB hex string as an 80 x 20 pixel colored rectangle, overlaid with the hex color string"
         },
@@ -455,6 +456,10 @@
         "truncate": {
           "type": "boolean",
           "description": "Causes long values to be truncated. By default, truncation is not enabled for fields."
+        },
+        "htmlCode": {
+          "type": "string",
+          "description": "HTML code to display in a cell. Use {value} to insert item value at this place"
         }
       },
       "required": [

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -130,7 +130,7 @@ export interface IConfigOptionSource {
   requestHeaders: any
 }
 
-export type TConfigDisplayField = 'text' | 'url' | 'image' | 'colorbox' | 'boolean';
+export type TConfigDisplayField = 'text' | 'url' | 'image' | 'colorbox' | 'boolean' | 'html';
 
 export interface IConfigDisplayField {
   name: string
@@ -141,6 +141,7 @@ export interface IConfigDisplayField {
   truncate: boolean
   url: string
   urlLabel?: string
+  htmlCode?: string;
 }
 
 export interface IConfigGetAllMethod extends IConfigMethod {
@@ -177,8 +178,8 @@ export interface IConfigCustomAction extends IConfigMethod {
   fields: IConfigInputField[]
 }
 
-export type IConfigPagination = 
-  IConfigQueryPagination | 
+export type IConfigPagination =
+  IConfigQueryPagination |
   IConfigBodyPagination;
 
 export type IConfigQueryPagination = _IConfigPagination<'query', IConfigQueryPaginationParams>;

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -64,6 +64,9 @@ export const Cards = ({ items, fields, callbacks, customActions, customLabels, p
         return <a href={url} target="_blank" rel="noopener noreferrer">{origField.urlLabel || value}</a>;
       case 'colorbox':
         return <div className="colorbox" style={{ backgroundColor: value }}></div>;
+      case 'html':
+        const html = origField.htmlCode ? origField.htmlCode.replace('{value}', value) : 'Undefined';
+        return <div dangerouslySetInnerHTML={{__html: html}}></div>
       default:
         return value;
     }

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -65,7 +65,8 @@ export const Cards = ({ items, fields, callbacks, customActions, customLabels, p
       case 'colorbox':
         return <div className="colorbox" style={{ backgroundColor: value }}></div>;
       case 'html':
-        const html = origField.htmlCode ? origField.htmlCode.replace('{value}', value) : 'Undefined';
+        const htmlCode = origField.htmlCode || '<span>{value}</span>';
+        const html =  htmlCode.replace('{value}', value);
         return <div dangerouslySetInnerHTML={{__html: html}}></div>
       default:
         return value;

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -62,6 +62,9 @@ export const Table = ({ items, fields, pagination, callbacks, customActions, cus
         return <a href={url} target="_blank" rel="noopener noreferrer">{origField.urlLabel || value}</a>;
       case 'colorbox':
         return <div className="colorbox" style={{ backgroundColor: value }}></div>;
+      case 'html':
+        const html = origField.htmlCode ? origField.htmlCode.replace('{value}', value) : 'Undefined';
+        return <div dangerouslySetInnerHTML={{__html: html}}></div>
       default:
         return value;
     }

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -63,7 +63,8 @@ export const Table = ({ items, fields, pagination, callbacks, customActions, cus
       case 'colorbox':
         return <div className="colorbox" style={{ backgroundColor: value }}></div>;
       case 'html':
-        const html = origField.htmlCode ? origField.htmlCode.replace('{value}', value) : 'Undefined';
+        const htmlCode = origField.htmlCode || '<span>{value}</span>';
+        const html =  htmlCode.replace('{value}', value);
         return <div dangerouslySetInnerHTML={{__html: html}}></div>
       default:
         return value;


### PR DESCRIPTION
Hi !

I would like to add this feature that allow html code in a display field (in cards or tab). 

Following example put value in bold and italic :
```json
{
  "name": "id",
  "label": "ID",
  "type": "html",
  "htmlCode": "<b><i>{value}</i></b>"
}
```

What do you think about this feature ?

Anthony