### PR TITLE
fixes dsternlicht/RESTool#186: sort items provided by optionSource via prop(s) defined in sortBy

### DIFF
--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -127,7 +127,7 @@ export interface IConfigOptionSource {
   displayPath: string
   valuePath: string
   actualMethod: TConfigMethod
-  sortBy: string
+  sortBy?: string | string[]
   requestHeaders: any
 }
 

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -410,7 +410,7 @@ const PageComp = ({ context }: IProps) => {
       updatedParams = buildInitQueryParamsAndPaginationState(updatedParams, paginationConfig).initQueryParams;
     }
 
-    updatedParams.map((queryParam, idx) => {
+    updatedParams.forEach((queryParam, idx) => {
         if (queryParam.type === 'select' && queryParam.value === '-- Select --') {
             // default value means nothing was selected and thus we explicitly
             // empty out the value in this case; otherwise the string '-- Select --'


### PR DESCRIPTION
- also fixed typing of `optionSource.sortBy`
- also fixed linter warning _"Expected to return a value in arrow function  array-callback-return"_