### PR TITLE
Method listing corrected to include "delete"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A method object will tell RESTool how to work with your API. Available methods:
 * getSingle
 * post
 * put
-* post
+* delete
 
 Each method has the following common properties (which could be extended specifically for each use case):
 


### PR DESCRIPTION
The method listing incorrectly included post twice, and did not include delete. This change fixes that.