### PR TITLE
Feature/make response an array

### DIFF
--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -251,7 +251,7 @@ const PageComp = ({ context }: IProps) => {
     }
 
     if (!Array.isArray(extractedData)) {
-    extractedData = [extractedData];
+      extractedData = [extractedData];
     }
 
     if (typeof params.dataTransform === 'function') {

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -251,7 +251,7 @@ const PageComp = ({ context }: IProps) => {
     }
 
     if (!Array.isArray(extractedData)) {
-      throw new Error('Extracted data is invalid.');
+    extractedData = [extractedData];
     }
 
     if (typeof params.dataTransform === 'function') {


### PR DESCRIPTION
Transform result that is not an array into an array for further processing. Allows RESTool to display information from a REST path that returns a single result instead of an array. 