### PR TITLE
Add dataTransform to post and put methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,19 @@ Example:
 }
 ```
 
+###### `dataTransform` (Function | async Function)
+
+Optional. Relevant only when using dynamic (js) config.
+A function to allow manipulation on the data before making the request.
+
+Here is an example for adding a new field named `wiki` to the data:
+```
+{
+  ...
+  "dataTransform": items => items.map(item => Object.assign(item, { wiki: `https://en.wikipedia.org/wiki/${item.name}` }))
+}
+```
+
 <br />
 
 #####  `put` - additional properties
@@ -300,6 +313,19 @@ Example:
 ###### `includeOriginalFields` (boolean)
 When set to `true`, all fields from the original object are merged and sent in the request body.
 Default is `false`.
+
+###### `dataTransform` (Function | async Function)
+
+Optional. Relevant only when using dynamic (js) config.
+A function to allow manipulation on the data before making the request.
+
+Here is an example for adding a new field named `wiki` to the data:
+```
+{
+  ...
+  "dataTransform": items => items.map(item => Object.assign(item, { wiki: `https://en.wikipedia.org/wiki/${item.name}` }))
+}
+```
 
 <br />
 

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -168,10 +168,12 @@ export interface IConfigGetSingleMethod extends IConfigMethod {
 
 export interface IConfigPostMethod extends IConfigMethod {
   fields: IConfigInputField[]
+  dataTransform?: ConfigFunction
 }
 
 export interface IConfigPutMethod extends IConfigMethod {
   fields: IConfigInputField[]
+  dataTransform?: ConfigFunction
   includeOriginalFields?: boolean
 }
 

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -201,7 +201,12 @@ export const FormPopup = withAppContext(({ context, title, fields, rawData, getS
     setLoading(true);
 
     try {
-      const body = containFiles ? formData : unflatten(finalObject);
+      let body = containFiles ? formData : unflatten(finalObject);
+
+      if (typeof methodConfig.dataTransform === 'function') {
+        body = await methodConfig.dataTransform(body)
+      }
+
       await submitCallback(body, containFiles, queryParams);
 
       toast.success('Great Success!');


### PR DESCRIPTION
Adding dataTransform to these methods means that data can be transformed before the request is made, meaning new fields can be added; fields can be adjusted to better match the API signature.

Also updated the README with the new functionality