### PR TITLE
Data transform being called twice for custom actions

### DIFF
--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -203,10 +203,6 @@ export const FormPopup = withAppContext(({ context, title, fields, rawData, getS
     try {
       let body = containFiles ? formData : unflatten(finalObject);
 
-      if (typeof methodConfig.dataTransform === 'function') {
-        body = await methodConfig.dataTransform(body)
-      }
-
       await submitCallback(body, containFiles, queryParams);
 
       toast.success('Great Success!');


### PR DESCRIPTION
Hi again, 

With my latest change (adding dataTransform to put/post) I introduced a bug where dataTransform will get called twice for custom actions. This PR removes dataTransform from customAction code as it is now handled elsewhere.