### PR TITLE
Made button labels and styles more configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,12 @@ Here's a list of variable names you may change:
 | actionButtonHoverBackground | `string` | Action button background color on hover event. |
 | actionButtonText | `string` | Action button text color. |
 | cardBackground | `string` | Card background color. |
+| addButtonText | `string` |  Add button text color. |
+| addButtonBackground | `string` | Add button background color. |
+| addButtonHoverBackground | `string` | Add button background color. (hover event) |
+| submitButtonText | `string` | Submit button text color. |
+| submitButtonBackground | `string` | Submit button background color. |
+| submitButtonHoverBackground | `string` | Submit button background color. (hover event) |
 
 Usage example in `config.json` file:
 
@@ -524,6 +530,7 @@ List of variable names you may change within the `buttons`property:
 | clearInput   | `string` | Title of the clear button on form inputs.          | Clear         |
 | closeForm    | `string` | Title of the close button in forms.                | Close         |
 | addArrayItem | `string` | Title of the add button on arrays inputs in forms. | Add Item      |
+| submitItem   | `string` | Content of the submit button on forms.
 
 List of variable names you may change within the `formTitles` property:
 

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -103,6 +103,26 @@
             "cardBackground": {
               "type": "string",
               "description": "Card background color."
+            },
+            "addButtonBackground": {
+              "type": "string",
+              "description": "Add button background color."
+            },
+            "addButtonHoverBackground": {
+              "type": "string",
+              "description": "Add button background color on hover event."
+            },
+            "addButtonText": {
+              "type": "string",
+              "description": "Add button text  color."
+            },
+            "submitButtonBackground": {
+              "type": "string",
+              "description": "Submit button background color."
+            },
+            "submitButtonText": {
+              "type": "string",
+              "description": "Submit button text  color."
             }
           }
         }
@@ -693,6 +713,11 @@
           "type": "string",
           "description": "Title of the add button on arrays inputs in forms.",
           "default": "Add Item"
+        },
+        "submitItem": {
+          "type": "string",
+          "description": "Title of the submit button on forms.",
+          "default": "Submit"
         }
       }
     },

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -44,6 +44,7 @@ export interface ICustomButtonLabels {
   clearInput?: string
   closeForm?: string
   addArrayItem?: string
+  submitItem?: string
 }
 
 export interface ICustomFormTitleLabels {

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -255,7 +255,7 @@ export const FormPopup = withAppContext(({ context, title, fields, rawData, getS
                 })
               }
               <div className="buttons-wrapper center">
-                <Button type="submit" onClick={submitForm} color="green">Submit</Button>
+                <Button type="submit" onClick={submitForm} >{customLabels?.buttons?.submitItem || 'Submit' }</Button>
               </div>
             </form>
           }

--- a/src/components/formPopup/formPopup.scss
+++ b/src/components/formPopup/formPopup.scss
@@ -1,3 +1,5 @@
+@import '../../common/styles//functions.scss';
+
 .form-popup {
   .popup-content {
     width: 90%;
@@ -35,6 +37,8 @@
         padding: 7px 15px;
         text-transform: uppercase;
         font-weight: 400;
+        background-color: v(submitButtonBackground, "green");
+        color: v(submitButtonText, "#000000");
       }
     }
   }

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -752,7 +752,7 @@ const PageComp = ({ context }: IProps) => {
         </hgroup>
         {
           postConfig &&
-          <Button className="add-item" color="green" onClick={() => setOpenedPopup({ type: 'add', title: addItemFormTitle, config: postConfig, submitCallback: addItem })}>{addItemLabel}</Button>
+          <Button className="add-item"  onClick={() => setOpenedPopup({ type: 'add', title: addItemFormTitle, config: postConfig, submitCallback: addItem })}>{addItemLabel}</Button>
         }
       </header>
       <main className="app-page-content">

--- a/src/components/page/page.scss
+++ b/src/components/page/page.scss
@@ -1,3 +1,5 @@
+@import '../../common/styles/functions';
+
 .app-page {
   flex: 1;
   display: flex;
@@ -24,6 +26,12 @@
   .add-item {
     font-size: 18px;
     padding: 12px 30px;
+    background-color: v(addButtonBackground, #1cb841);
+    color: v(addButtonText, #ffffff);
+
+    &:hover {
+      background-color: v(addButtonHoverBackground, lighten(#1cb841, 10%));
+    }
 
     @media screen and (max-width: 800px) { 
       margin-top: 15px;


### PR DESCRIPTION
Hello, when using the tool to create a localized prototype i realized that not all button texts and colors where customizable, so I added some vars to make them customizable.

Color of the add button.
Text and color of the submit button in forms.

See README.md changes for further details.