### PR TITLE
Internationalization i18n (Multi Language Support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Each **page** is an object and represents a resource in your API. It should have
 
 | Property | Type | Required? | Description |
 |----------------|--------------|-----|----------------------------------------------------------------|
-| name | `string` | true | The name of the page. This will be presented in the menu. <br> ⚠️ Deprecated. Define in i18n language files under the page's namespace. |
+| name | `string` | true | The name of the page. This will be presented in the menu. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | id | `string` | true | A unique identifier for the page. RESTool will use it to navigate between pages. |
-| description | `string` | false | A short description about the page and its usage.  <br> ⚠️ Deprecated. Define in i18n language files under the page's namespace.|
+| description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | requestHeaders | `object` | false | A list of key-value headers you wish to add to every request we're making. <br /><br /> For example: <br />``{ Authentication: 'SECRET_KEY', 'X-USER-ID': 'USER_ID' }``. |
 | methods | `object` | true | A list of all methods which are available in your RESTful API. |
 | customActions | `object[]` | false | A list of extra (non RESTful) endpoints available in your RESTful API. Specifically `customActions` is a list of PUT or POST method objects. <br /><br />Read more about custom actions [here](#custom-actions). |
@@ -653,7 +653,7 @@ The list of fields you want to present in the main view of the app. Each one is 
 |----------------|--------------|-----|----------------------------------------------------------------|
 | name | `string` | true | The property name of the field that contains the value in the API result. |
 | type | `string` | true | This will help RESTool to render the main view. See a list of available type below. |
-| label | `string` | false | ⚠️ Deprecated. Define field labels in i18n language files. See [Internationalization (i18n)](#internationalization-i18n) section. |
+| label | `string` | false | A label that describes the field. Will be presented as table headers in the main view. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | dataPath | `string` | false | Read more about dataPath [here](#data-path).
 | filterable | `boolean` | false | Set to `true` to enable a text control to do simple client-side filtering by values of this field. Can be specified for multiple fields. |
 | truncate | `boolean` | false | Causes long values to be truncated. By default, truncation is not enabled for fields. |

--- a/README.md
+++ b/README.md
@@ -1,24 +1,16 @@
 # RESTool 2.0 ([demo](https://dsternlicht.github.io/RESTool/))
 
-
-
 <p  align="center">
 
 <img  src="https://raw.githubusercontent.com/dsternlicht/RESTool/master/screenshots/screenshot_1.png?raw=true"  alt="RESTool Sample App"/>
 
 </p>
 
-
-
 The best tool in the neighborhood. Managing your **RESTful APIs** has never been so easy.
 
 RESTool gives you an out of the box UI that connects to your RESTful API with a simple configuration file.
 
-
-
 The idea behind it is simple. Given the fact that each entity in your API has a RESTful implementation, RESTool will provide you UI tool for managing these entities in no time by simply editing a configuration file. No front end engineers, no JavaScript, no CSS, no html. Just a simple JSON file.
-
-
 
 **Live Demo**: [https://dsternlicht.github.io/RESTool/](https://dsternlicht.github.io/RESTool/)
 
@@ -36,6 +28,7 @@ Some new features and capabilities in V2:
 * Custom app colors
 * Data path extraction from arrays
 * New & improved design
+* Internationalization (i18n) support with auto-detect browser language
 * Custom favicon support
 * Custom icons for actions
 * Better error handling in configuration and requests
@@ -71,7 +64,7 @@ Here's a detailed list of properties you could add to your configuration file (j
 | auth | `object` | false | Built-in authentication configuration (used only if `unauthorizedRedirectUrl` is not set). See [Auth Config](#auth-config) below. |
 | favicon | `string` | false | A URL for you app's favicon. |
 | customStyles | `object` | false | [Custom styles](#custom-styles) |
-| customLabels | `object` | false | [Custom labels](#custom-labels) |
+| customLabels | `object` | false | ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section. <br> [Custom labels](#custom-labels) |
 | customLink | `string` | false | External Link for navigation item (instead of default page app) |
 
 #### Dynamic configuration file
@@ -86,6 +79,7 @@ export default {
 
 **NOTE:** In case you're using the `build` folder, the config.js must be placed in the folder `/build/static/js`.
 <br />
+
 
 ### Auth Config
 
@@ -142,13 +136,13 @@ Each **page** is an object and represents a resource in your API. It should have
 
 | Property | Type | Required? | Description |
 |----------------|--------------|-----|----------------------------------------------------------------|
-| name | `string` | true | The name of the page. This will be presented in the menu.|
+| name | `string` | true | The name of the page. This will be presented in the menu. <br> ⚠️ Deprecated. Define in i18n language files under the page's namespace. |
 | id | `string` | true | A unique identifier for the page. RESTool will use it to navigate between pages. |
-| description | `string` | false | A short description about the page and its usage. |
+| description | `string` | false | A short description about the page and its usage.  <br> ⚠️ Deprecated. Define in i18n language files under the page's namespace.|
 | requestHeaders | `object` | false | A list of key-value headers you wish to add to every request we're making. <br /><br /> For example: <br />``{ Authentication: 'SECRET_KEY', 'X-USER-ID': 'USER_ID' }``. |
 | methods | `object` | true | A list of all methods which are available in your RESTful API. |
 | customActions | `object[]` | false | A list of extra (non RESTful) endpoints available in your RESTful API. Specifically `customActions` is a list of PUT or POST method objects. <br /><br />Read more about custom actions [here](#custom-actions). |
-| customLabels | `object` | false | [Custom labels](#custom-labels) |
+| customLabels | `object` | false | [Custom labels](#custom-labels) <br> ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 
 <br />
 
@@ -569,6 +563,9 @@ Usage example in `config.json` file:
 
 ####  Custom Labels
 
+> ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section.
+
+
 The `customLabels` property allows you to control the different labels that are shown across the pages of your RESTool app. The object has three fields that contain properties that you can customize: `buttons`, `formTitles`, `placeholders`, `successMessages` and `pagination`.
 
 List of variable names you may change within the `buttons`property:
@@ -656,7 +653,7 @@ The list of fields you want to present in the main view of the app. Each one is 
 |----------------|--------------|-----|----------------------------------------------------------------|
 | name | `string` | true | The property name of the field that contains the value in the API result. |
 | type | `string` | true | This will help RESTool to render the main view. See a list of available type below. |
-| label | `string` | false | A label that describes the field. Will be presented as table headers in the main view. |
+| label | `string` | false | ⚠️ Deprecated. Define field labels in i18n language files. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | dataPath | `string` | false | Read more about dataPath [here](#data-path).
 | filterable | `boolean` | false | Set to `true` to enable a text control to do simple client-side filtering by values of this field. Can be specified for multiple fields. |
 | truncate | `boolean` | false | Causes long values to be truncated. By default, truncation is not enabled for fields. |
@@ -870,6 +867,77 @@ The field name will be `url`, the type will be `text`, and the data path will be
 
 
 <br />
+
+### Internationalization (i18n)
+
+RESTool supports internationalization (i18n) of your application through language files. This allows you to provide your application in multiple languages.
+
+#### Language Configuration
+
+1. Create language files in the `src/locales` directory (e.g., `fr.json`, `de.json`, ...) with translations.
+Use the `en.json` file as a template for the structure of the language files.
+
+2. The browser language is automatically detected and the corresponding language file is loaded. Falls back to English (en) if the detected language is not available.
+
+#### Page-Specific Translations
+
+##### Title and description (subtitle)
+Define the title and description of a page in the language files under the page's namespace. 
+Use the `id` of the page as defined in the configuration file.
+For example, for the "Characters" page:
+
+```json
+{
+  "pages": {
+    "characters": {
+      "title": "Personnages",
+      "description": "Liste des personnages"
+    }
+  }
+}
+```
+
+##### Field labels
+
+Define the field labels in the language files under the namespace of the page.
+Use the `id` of the page as defined in the configuration file.
+Then define the translations of the field labels under the `fields` property with the field `name` as the key.
+For example, for the "Characters" page:
+
+```json
+{
+  "pages": {
+    "characters": {
+      "fields": {
+        "name": "Nom",
+        "age": "Âge",
+      }
+    }
+  }
+}
+```
+
+##### Other translations
+
+You can also override all translations of the `global` namespace for a specific page.
+
+```json
+{
+  "pages": [
+    {
+      "characters": {
+        "title": "Personnages",
+        "description": "Liste des personnages",
+        // Page-specific translations, overwrites translations of the `global` properties
+        "buttons": {
+          "addItem": "Ajouter un personnage",
+          "editItem": "Modifier",
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here's a detailed list of properties you could add to your configuration file (j
 | auth | `object` | false | Built-in authentication configuration (used only if `unauthorizedRedirectUrl` is not set). See [Auth Config](#auth-config) below. |
 | favicon | `string` | false | A URL for you app's favicon. |
 | customStyles | `object` | false | [Custom styles](#custom-styles) |
-| customLabels | `object` | false | ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section. <br> [Custom labels](#custom-labels) |
+| customLabels | `object` | false | [Custom labels](#custom-labels) <br> ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | customLink | `string` | false | External Link for navigation item (instead of default page app) |
 
 #### Dynamic configuration file

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "@types/react-router-dom": "^5.1.3",
         "ajv": "^6.12.1",
         "flat": "^5.0.0",
+        "i18next": "^21.6.16",
+        "i18next-browser-languagedetector": "^8.0.4",
+        "i18next-resources-to-backend": "^1.2.1",
         "jsoneditor": "^9.5.6",
         "jsoneditor-react": "^3.1.1",
         "lodash": "^4.17.21",
@@ -22,6 +25,7 @@
         "query-string": "^6.9.0",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-i18next": "^11.18.6",
         "react-infinite-scroll-component": "^5.0.4",
         "react-loading-skeleton": "^2.0.1",
         "react-router-dom": "^5.1.2",
@@ -1907,11 +1911,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1928,6 +1933,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -9185,6 +9196,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -9345,6 +9365,47 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "21.6.16",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.16.tgz",
+      "integrity": "sha512-xJlzrVxG9CyAGsbMP1aKuiNr1Ed2m36KiTB7hjGMG2Zo4idfw3p9THUEu+GjBwIgEZ7F11ZbCzJcfv4uyfKNuw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.4.tgz",
+      "integrity": "sha512-f3frU3pIxD50/Tz20zx9TD9HobKYg47fmAETb117GKGPrhwcSSPJDoCposXlVycVebQ9GQohC3Efbpq7/nnJ5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-resources-to-backend": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.1.tgz",
+      "integrity": "sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -14667,6 +14728,28 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "node_modules/react-i18next": {
+      "version": "11.18.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 19.0.0",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-infinite-scroll-component": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-5.1.0.tgz",
@@ -17103,6 +17186,15 @@
         "node": ">=0.10.48"
       }
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -19305,11 +19397,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -24777,6 +24876,14 @@
         }
       }
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      }
+    },
     "html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -24886,6 +24993,30 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+    },
+    "i18next": {
+      "version": "21.6.16",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.6.16.tgz",
+      "integrity": "sha512-xJlzrVxG9CyAGsbMP1aKuiNr1Ed2m36KiTB7hjGMG2Zo4idfw3p9THUEu+GjBwIgEZ7F11ZbCzJcfv4uyfKNuw==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "i18next-browser-languagedetector": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.4.tgz",
+      "integrity": "sha512-f3frU3pIxD50/Tz20zx9TD9HobKYg47fmAETb117GKGPrhwcSSPJDoCposXlVycVebQ9GQohC3Efbpq7/nnJ5w==",
+      "requires": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "i18next-resources-to-backend": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.1.tgz",
+      "integrity": "sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==",
+      "requires": {
+        "@babel/runtime": "^7.23.2"
+      }
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -28821,6 +28952,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "react-i18next": {
+      "version": "11.18.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
+      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "requires": {
+        "@babel/runtime": "^7.14.5",
+        "html-parse-stringify": "^3.0.1"
+      }
+    },
     "react-infinite-scroll-component": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-5.1.0.tgz",
@@ -30601,6 +30741,11 @@
       "resolved": "https://registry.npmjs.org/version-guard/-/version-guard-1.1.1.tgz",
       "integrity": "sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==",
       "dev": true
+    },
+    "void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "@types/react-router-dom": "^5.1.3",
     "ajv": "^6.12.1",
     "flat": "^5.0.0",
+    "i18next": "^21.6.16",
+    "i18next-browser-languagedetector": "^8.0.4",
+    "i18next-resources-to-backend": "^1.2.1",
     "jsoneditor": "^9.5.6",
     "jsoneditor-react": "^3.1.1",
     "lodash": "^4.17.21",
@@ -16,6 +19,7 @@
     "query-string": "^6.9.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-i18next": "^11.18.6",
     "react-infinite-scroll-component": "^5.0.4",
     "react-loading-skeleton": "^2.0.1",
     "react-router-dom": "^5.1.2",
@@ -25,7 +29,7 @@
     "typescript": "^3.7.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3006 react-scripts start",
     "build": "react-scripts build",
     "build-lib": "tsc --project ./tsconfig.lib.json",
     "test": "react-scripts test",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^3.7.4"
   },
   "scripts": {
-    "start": "PORT=3006 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "build-lib": "tsc --project ./tsconfig.lib.json",
     "test": "react-scripts test",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -15,6 +15,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { LoginPage } from './auth/loginPage/loginPage.comp';
 import { ChangePasswordPage } from './auth/changePasswortPage/changePasswortPage.comp';
 import AuthService from '../services/auth.service';
+import { useTranslation } from 'react-i18next';
 
 const httpService = new HttpService();
 const authService = new AuthService();
@@ -38,6 +39,7 @@ function App() {
   const [activePage, setActivePage] = useState<IConfigPage | null>(config?.pages?.[0] || null);
   const [error, setError] = useState<string | null>(null);
   const [loggedInUsername, setLoggedInUsername] = useState<string | null>(null);
+  const { t } = useTranslation();
 
   const appName: string = config?.name || defaultAppName;
 
@@ -130,8 +132,9 @@ function App() {
       {
         !config ?
           <div className="app-error">
-            {firstLoad ? 'Loading Configuration...' : 'Could not find config file.'}
-          </div> :
+             {firstLoad ? t('common.loadingConfiguration') : t('common.loadingConfigurationFailed')}
+          
+            </div> :
           <AppContext.Provider value={{ config, activePage, setActivePage, error, setError, httpService, authService, loggedInUsername, setLoggedInUsername }}>
             {
               config.customStyles &&

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -15,7 +15,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { LoginPage } from './auth/loginPage/loginPage.comp';
 import { ChangePasswordPage } from './auth/changePasswortPage/changePasswortPage.comp';
 import AuthService from '../services/auth.service';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../hooks/usePageTranslation';
 
 const httpService = new HttpService();
 const authService = new AuthService();
@@ -39,7 +39,7 @@ function App() {
   const [activePage, setActivePage] = useState<IConfigPage | null>(config?.pages?.[0] || null);
   const [error, setError] = useState<string | null>(null);
   const [loggedInUsername, setLoggedInUsername] = useState<string | null>(null);
-  const { t } = useTranslation();
+  const { translate } = usePageTranslation();
 
   const appName: string = config?.name || defaultAppName;
 
@@ -132,7 +132,7 @@ function App() {
       {
         !config ?
           <div className="app-error">
-             {firstLoad ? t('common.loadingConfiguration') : t('common.loadingConfigurationFailed')}
+             {firstLoad ? translate('configuration.loadingConfiguration') : translate('configuration.loadingConfigurationFailed')}
           
             </div> :
           <AppContext.Provider value={{ config, activePage, setActivePage, error, setError, httpService, authService, loggedInUsername, setLoggedInUsername }}>

--- a/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
+++ b/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../../button/button.comp';
 import { toast } from 'react-toastify';
 
@@ -17,20 +18,21 @@ export const ChangePasswordPage = withAppContext(
     const [oldPwd, setOldPwd] = useState<string>('');
     const [newPwd, setNewPwd] = useState<string>('');
     const [confirmPwd, setConfirmPwd] = useState<string>('');
-    const { authService, } = context;
+    const { authService } = context;
+    const { t } = useTranslation();
 
     async function submitForm(e: any) {
       e.preventDefault();
       if (newPwd !== confirmPwd) {
-        toast.error('Confirmed password does not match');
+        toast.error(t('auth.passwordMismatch'));
         return;
       }
       try {
         await authService.changePassword(oldPwd, newPwd);
-        toast.success('Password changed successfully');
+        toast.success(t('auth.passwordChanged'));
         replace('/');
       } catch (error) {
-        toast.error('Password change failed');
+        toast.error(t('auth.passwordChangeFailed'));
       }
     }
 
@@ -50,19 +52,33 @@ export const ChangePasswordPage = withAppContext(
       <div className="change-pwd-page">
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
-            <label>Old Password</label>
-            <input type="password" placeholder='Enter old password...' onChange={handleOldPwdChange} />
+            <label>{t('auth.labels.oldPassword')}</label>
+            <input 
+              type="password" 
+              placeholder={t('placeholders.oldPassword')}
+              onChange={handleOldPwdChange} 
+            />
           </div>
           <div className='form-row row'>
-            <label>New Password</label>
-            <input type="password" placeholder='Enter new password...' onChange={handleNewPwdChange} />
+            <label>{t('auth.labels.newPassword')}</label>
+            <input 
+              type="password" 
+              placeholder={t('placeholders.newPassword')}
+              onChange={handleNewPwdChange} 
+            />
           </div>
           <div className='form-row row'>
-            <label>Confirm New Password</label>
-            <input type="password" placeholder='Confirm new password...' onChange={handleConfirmPwdChange} />
+            <label>{t('auth.labels.confirmPassword')}</label>
+            <input 
+              type="password" 
+              placeholder={t('placeholders.confirmPassword')}
+              onChange={handleConfirmPwdChange} 
+            />
           </div>
           <div className="buttons-wrapper center">
-            <Button type="submit" onClick={submitForm} color="green">Submit</Button>
+            <Button type="submit" onClick={submitForm} color="green">
+              {t('buttons.submit')}
+            </Button>
           </div>
         </form>
       </div>

--- a/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
+++ b/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../../hooks/usePageTranslation';
 import { Button } from '../../button/button.comp';
 import { toast } from 'react-toastify';
 
@@ -19,32 +19,32 @@ export const ChangePasswordPage = withAppContext(
     const [newPwd, setNewPwd] = useState<string>('');
     const [confirmPwd, setConfirmPwd] = useState<string>('');
     const { authService } = context;
-    const { t } = useTranslation();
+    const { translate } = usePageTranslation();
 
-    async function submitForm(e: any) {
+    async function submitForm(e: React.FormEvent<HTMLFormElement>) {
       e.preventDefault();
       if (newPwd !== confirmPwd) {
-        toast.error(t('auth.passwordMismatch'));
+        toast.error(translate('auth.passwordMismatch'));
         return;
       }
       try {
         await authService.changePassword(oldPwd, newPwd);
-        toast.success(t('auth.passwordChanged'));
+        toast.success(translate('auth.passwordChanged'));
         replace('/');
       } catch (error) {
-        toast.error(t('auth.passwordChangeFailed'));
+        toast.error(translate('auth.passwordChangeFailed'));
       }
     }
 
-    function handleOldPwdChange(event: any) {
+    function handleOldPwdChange(event: React.ChangeEvent<HTMLInputElement>) {
       setOldPwd(event.target.value);
     }
 
-    function handleNewPwdChange(event: any) {
+    function handleNewPwdChange(event: React.ChangeEvent<HTMLInputElement>) {
       setNewPwd(event.target.value);
     }
 
-    function handleConfirmPwdChange(event: any) {
+    function handleConfirmPwdChange(event: React.ChangeEvent<HTMLInputElement>) {
       setConfirmPwd(event.target.value);
     }
 
@@ -52,32 +52,32 @@ export const ChangePasswordPage = withAppContext(
       <div className="change-pwd-page">
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
-            <label>{t('auth.labels.oldPassword')}</label>
+            <label>{translate('auth.labels.oldPassword')}</label>
             <input 
               type="password" 
-              placeholder={t('placeholders.oldPassword')}
+              placeholder={translate('auth.placeholders.oldPassword')}
               onChange={handleOldPwdChange} 
             />
           </div>
           <div className='form-row row'>
-            <label>{t('auth.labels.newPassword')}</label>
+            <label>{translate('auth.labels.newPassword')}</label>
             <input 
               type="password" 
-              placeholder={t('placeholders.newPassword')}
+              placeholder={translate('auth.placeholders.newPassword')}
               onChange={handleNewPwdChange} 
             />
           </div>
           <div className='form-row row'>
-            <label>{t('auth.labels.confirmPassword')}</label>
+            <label>{translate('auth.labels.confirmPassword')}</label>
             <input 
               type="password" 
-              placeholder={t('placeholders.confirmPassword')}
+              placeholder={translate('auth.placeholders.confirmPassword')}
               onChange={handleConfirmPwdChange} 
             />
           </div>
           <div className="buttons-wrapper center">
             <Button type="submit" onClick={submitForm} color="green">
-              {t('buttons.submit')}
+              {translate('auth.changePassword')}
             </Button>
           </div>
         </form>

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -77,7 +77,7 @@ export const LoginPage = withAppContext(
           </div>
           <div className="buttons-wrapper center">
             <Button type="submit" onClick={submitForm} color="green">
-              {translate('buttons.login')}
+              {translate('auth.login')}
             </Button>
           </div>
         </form>

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../../hooks/usePageTranslation';
 import { Button } from '../../button/button.comp';
 import { toast } from 'react-toastify';
 
@@ -16,7 +16,7 @@ export const LoginPage = withAppContext(
   ({ context }: IProps) => {
     const history = useHistory();
     const location = useLocation();
-    const { t } = useTranslation();
+    const { translate } = usePageTranslation();
     const queryParams = new URLSearchParams(location.search);
     const returnUrl = queryParams.get('return');
     const [user, setUser] = useState<string>('');
@@ -29,7 +29,7 @@ export const LoginPage = withAppContext(
         const { passwordChangeRequired } = await authService.login(user, pwd);
         setLoggedInUsername(user);
         if (passwordChangeRequired) {
-          toast.info(t('auth.passwordChangeRequired'));
+          toast.info(translate('auth.passwordChangeRequired'));
           history.replace('/change-password');
           return;
         }
@@ -40,7 +40,7 @@ export const LoginPage = withAppContext(
           history.replace('/');
         }
       } catch (error) {
-        toast.error(t('auth.loginFailed'));
+        toast.error(translate('auth.loginFailed'));
         setPwd('');
         return;
       }
@@ -58,26 +58,26 @@ export const LoginPage = withAppContext(
       <div className="auth-page">
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
-            <label>{t('auth.labels.user')}</label>
+            <label>{translate('auth.labels.user')}</label>
             <input 
               type="text" 
-              placeholder={t('placeholders.user')}
+              placeholder={translate('auth.placeholders.user')}
               value={user} 
               onChange={handleUserChange} 
             />
           </div>
           <div className='form-row row'>
-            <label>{t('auth.labels.password')}</label>
+            <label>{translate('auth.labels.password')}</label>
             <input 
               type="password" 
-              placeholder={t('placeholders.password')}
+              placeholder={translate('auth.placeholders.password')}
               value={pwd} 
               onChange={handlePwdChange} 
             />
           </div>
           <div className="buttons-wrapper center">
             <Button type="submit" onClick={submitForm} color="green">
-              {t('buttons.submit')}
+              {translate('buttons.login')}
             </Button>
           </div>
         </form>

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Button } from '../../button/button.comp';
 import { toast } from 'react-toastify';
 
@@ -15,6 +16,7 @@ export const LoginPage = withAppContext(
   ({ context }: IProps) => {
     const history = useHistory();
     const location = useLocation();
+    const { t } = useTranslation();
     const queryParams = new URLSearchParams(location.search);
     const returnUrl = queryParams.get('return');
     const [user, setUser] = useState<string>('');
@@ -27,7 +29,7 @@ export const LoginPage = withAppContext(
         const { passwordChangeRequired } = await authService.login(user, pwd);
         setLoggedInUsername(user);
         if (passwordChangeRequired) {
-          toast.info('Password change required');
+          toast.info(t('auth.passwordChangeRequired'));
           history.replace('/change-password');
           return;
         }
@@ -38,8 +40,7 @@ export const LoginPage = withAppContext(
           history.replace('/');
         }
       } catch (error) {
-        toast.error('Login failed');
-        console.error(error);
+        toast.error(t('auth.loginFailed'));
         setPwd('');
         return;
       }
@@ -57,15 +58,27 @@ export const LoginPage = withAppContext(
       <div className="auth-page">
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
-            <label>User</label>
-            <input type="text" placeholder='Enter user....' value={user} onChange={handleUserChange} />
+            <label>{t('auth.labels.user')}</label>
+            <input 
+              type="text" 
+              placeholder={t('placeholders.user')}
+              value={user} 
+              onChange={handleUserChange} 
+            />
           </div>
           <div className='form-row row'>
-            <label>Password</label>
-            <input type="password" placeholder='Enter password...' value={pwd} onChange={handlePwdChange} />
+            <label>{t('auth.labels.password')}</label>
+            <input 
+              type="password" 
+              placeholder={t('placeholders.password')}
+              value={pwd} 
+              onChange={handlePwdChange} 
+            />
           </div>
           <div className="buttons-wrapper center">
-            <Button type="submit" onClick={submitForm} color="green">Submit</Button>
+            <Button type="submit" onClick={submitForm} color="green">
+              {t('buttons.submit')}
+            </Button>
           </div>
         </form>
       </div>

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { usePageTranslation } from "../../hooks/usePageTranslation";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Skeleton from "react-loading-skeleton";
 
@@ -35,9 +35,9 @@ interface IProps {
 }
 
 export const Cards = withAppContext(({ context, items, fields, callbacks, customActions, customLabels, pagination }: IProps) => {
-  const { t } = useTranslation();
-  const editLabel: string = customLabels?.buttons?.editItem || t('buttons.editItem');
-  const deleteLabel: string = customLabels?.buttons?.deleteItem || t('buttons.deleteItem');
+  const { translatePage } = usePageTranslation(context.activePage?.id);
+  const editLabel: string = customLabels?.buttons?.editItem || translatePage('buttons.editItem');
+  const deleteLabel: string = customLabels?.buttons?.deleteItem || translatePage('buttons.deleteItem');
   const paginationCallbacks = {
     nextPage:
       callbacks.getNextPage ||
@@ -169,7 +169,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
                     }
                   }}
                 >
-                  {field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}:{" "}
+                  {field.label || translatePage(`fields.${field.name}.label`) || field.name}:{" "}
                 </label>
               )}
               {renderRow(field, item, value)}
@@ -191,7 +191,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
               key={`card_${cardIdx}_${fieldIdx}`}
             >
               {field.type !== "image" && (
-                <label>{field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}: </label>
+                <label>{field.label || translatePage(`fields.${field.name}.label`) || field.name}: </label>
               )}
               <Skeleton duration={0.6} />
             </div>

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import InfiniteScroll from "react-infinite-scroll-component";
 import Skeleton from "react-loading-skeleton";
 
@@ -11,10 +12,13 @@ import { IPaginationState } from "../../common/models/states.model";
 import { dataHelpers } from "../../helpers/data.helpers";
 import { Button } from "../button/button.comp";
 import { Pagination } from "../pagination/pagination.comp";
+import { IAppContext } from "../app.context";
+import { withAppContext } from "../withContext/withContext.comp";
 
 import "./cards.scss";
 
 interface IProps {
+  context: IAppContext;
   items: any[];
   pagination?: IPaginationState;
   callbacks: {
@@ -30,16 +34,10 @@ interface IProps {
   customLabels?: ICustomLabels;
 }
 
-export const Cards = ({
-  items,
-  fields,
-  callbacks,
-  customActions,
-  customLabels,
-  pagination,
-}: IProps) => {
-  const editLabel: string = customLabels?.buttons?.editItem || "Edit";
-  const deleteLabel: string = customLabels?.buttons?.deleteItem || "Delete";
+export const Cards = withAppContext(({ context, items, fields, callbacks, customActions, customLabels, pagination }: IProps) => {
+  const { t } = useTranslation();
+  const editLabel: string = customLabels?.buttons?.editItem || t('buttons.editItem');
+  const deleteLabel: string = customLabels?.buttons?.deleteItem || t('buttons.deleteItem');
   const paginationCallbacks = {
     nextPage:
       callbacks.getNextPage ||
@@ -171,7 +169,7 @@ export const Cards = ({
                     }
                   }}
                 >
-                  {field.label || field.name}:{" "}
+                  {field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}:{" "}
                 </label>
               )}
               {renderRow(field, item, value)}
@@ -193,7 +191,7 @@ export const Cards = ({
               key={`card_${cardIdx}_${fieldIdx}`}
             >
               {field.type !== "image" && (
-                <label>{field.label || field.name}: </label>
+                <label>{field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}: </label>
               )}
               <Skeleton duration={0.6} />
             </div>
@@ -216,8 +214,8 @@ export const Cards = ({
     if (
       pagination?.type === "infinite-scroll" &&
       document.body.clientHeight <= window.innerHeight &&
-      callbacks.getNextPage &&
-      pagination?.hasNextPage
+      pagination?.hasNextPage &&
+      callbacks.getNextPage
     ) {
       callbacks.getNextPage();
     }
@@ -245,8 +243,9 @@ export const Cards = ({
         <Pagination
           callbacks={paginationCallbacks}
           pagination={pagination}
+          customLabels={customLabels}
         ></Pagination>
       )}
     </React.Fragment>
   );
-};
+});

--- a/src/components/filterField/filterField.comp.tsx
+++ b/src/components/filterField/filterField.comp.tsx
@@ -1,25 +1,30 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
+import { withAppContext } from '../withContext/withContext.comp';
+import { IAppContext } from '../app.context';
 
 import './filterField.scss';
 
 interface IProps {
+  context: IAppContext;
   onChange: (filter: string) => void
 }
 
-export const FilterField = ({ onChange }: IProps) => {
-  const { t } = useTranslation();
+const FilterFieldComp = ({ context, onChange }: IProps) => {
+  const { translatePage } = usePageTranslation(context.activePage?.id);
 
   return (
     <section className="filter-wrapper">
-      <h5>{t('filter.title')}</h5>
+      <h5>{translatePage('filter.title')}</h5>
       <div className="form-row">
         <input 
           type="text" 
-          placeholder={t('filter.searchPlaceholder')} 
+          placeholder={translatePage('filter.searchPlaceholder')} 
           onChange={(e) => onChange(e.target.value.toLowerCase())} 
         />
       </div>
     </section>
   );
 };
+
+export const FilterField = withAppContext(FilterFieldComp);

--- a/src/components/filterField/filterField.comp.tsx
+++ b/src/components/filterField/filterField.comp.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import './filterField.scss';
 
@@ -7,11 +8,17 @@ interface IProps {
 }
 
 export const FilterField = ({ onChange }: IProps) => {
+  const { t } = useTranslation();
+
   return (
     <section className="filter-wrapper">
-      <h5>Filter:</h5>
+      <h5>{t('filter.title')}</h5>
       <div className="form-row">
-        <input type="text" placeholder="Search..." onChange={(e) => onChange(e.target.value.toLowerCase())} />
+        <input 
+          type="text" 
+          placeholder={t('filter.searchPlaceholder')} 
+          onChange={(e) => onChange(e.target.value.toLowerCase())} 
+        />
       </div>
     </section>
   );

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -26,6 +26,7 @@ const unflatten = require('flat').unflatten;
 interface IProps {
   context: IAppContext
   title: string
+  type: string
   successMessage: string
   fields: IConfigInputField[]
   rawData?: any
@@ -35,7 +36,7 @@ interface IProps {
   submitCallback: (body: any, containFiles: boolean, queryParams: IQueryParam[]) => void
 }
 
-export const FormPopup = withAppContext(({ context, title, successMessage, fields, rawData, getSingleConfig, methodConfig, submitCallback, closeCallback }: IProps) => {
+export const FormPopup = withAppContext(({ context, title, type, successMessage, fields, rawData, getSingleConfig, methodConfig, submitCallback, closeCallback }: IProps) => {
   const fieldsCopy: IConfigInputField[] = fields.map(field => ({
     ...field,
     showFieldWhen: field.showFieldWhen
@@ -290,7 +291,12 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
                 }
                 <div className="buttons-wrapper center">
                   <Button type="submit" onClick={submitForm}>
-                    {customLabels?.buttons?.submitItem || translatePage('buttons.submitItem')}
+                    {(customLabels?.buttons?.submitItem ||
+                      type === 'add' ? translatePage('buttons.submitAdd') :
+                      type === 'action' ? translatePage('buttons.submitAction') :
+                        type === 'update' ? translatePage('buttons.submitUpdate') :
+                          '')
+                    }
                   </Button>
                 </div>
               </form>

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
 import { toast } from 'react-toastify';
 
 import { Popup } from '../popup/popup.comp';
@@ -41,7 +41,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
     showFieldWhen: field.showFieldWhen
   }));
   const { httpService, activePage, config } = context;
-  const { t } = useTranslation();
+  const { translatePage } = usePageTranslation(activePage?.id);
   const [loading, setLoading] = useState<boolean>(true);
   const [formFields, setFormFields] = useState<IConfigInputField[]>([]);
   const [finalRawData, setFinalRawData] = useState<any>(null);
@@ -73,8 +73,8 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
           finalRawData = extractedData;
         }
       } catch (e) {
-        console.error(t('forms.errors.loadItemFailed'), e);
-        toast.error(t('forms.errors.loadItemFailed'));
+        console.error(translatePage('forms.errors.loadItemFailed'), e);
+        toast.error(translatePage('forms.errors.loadItemFailed'));
       }
     }
 
@@ -185,14 +185,14 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
 
       // Replace the validation code with:
       if (field.required && field.type !== 'boolean' && isFieldValueEmpty(field)) {
-        validationError = t('forms.errors.requiredFields');
+        validationError = translatePage('forms.errors.requiredFields');
       }
 
       if (dataHelpers.checkIfFieldIsObject(field) && field.value) {
         try {
           finalObject[field.name] = JSON.parse(field.value);
         } catch (e) {
-          validationError = t('forms.errors.invalidJson', { field: field.name });
+          validationError = translatePage('forms.errors.invalidJson', { field: field.name });
         }
       }
 
@@ -250,7 +250,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
   function shouldFieldBeVisible(field: IConfigInputField, fields: IConfigInputField[]): boolean {
     if (!field.showFieldWhen) return true;
     if (typeof field.showFieldWhen !== 'function') {
-      console.warn(t('common.warnings.showFieldWhenFunction'));
+      console.warn(translatePage('common.warnings.showFieldWhenFunction'));
       return true;
     }
     return field.showFieldWhen(fields);
@@ -290,7 +290,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
                 }
                 <div className="buttons-wrapper center">
                   <Button type="submit" onClick={submitForm}>
-                    {customLabels?.buttons?.submitItem || t('buttons.submitItem')}
+                    {customLabels?.buttons?.submitItem || translatePage('buttons.submitItem')}
                   </Button>
                 </div>
               </form>

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
 
 import { Popup } from '../popup/popup.comp';
@@ -40,6 +41,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
     showFieldWhen: field.showFieldWhen
   }));
   const { httpService, activePage, config } = context;
+  const { t } = useTranslation();
   const [loading, setLoading] = useState<boolean>(true);
   const [formFields, setFormFields] = useState<IConfigInputField[]>([]);
   const [finalRawData, setFinalRawData] = useState<any>(null);
@@ -56,7 +58,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
           method: actualMethod || 'get',
           origUrl: url,
           queryParams,
-          headers: Object.assign({}, pageHeaders,  requestHeaders || {}),
+          headers: Object.assign({}, pageHeaders, requestHeaders || {}),
           rawData,
           responseType
         });
@@ -71,8 +73,8 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
           finalRawData = extractedData;
         }
       } catch (e) {
-        console.error('Could not load single item\'s data.', e);
-        toast.error('Could not load single item\'s data.');
+        console.error(t('forms.errors.loadItemFailed'), e);
+        toast.error(t('forms.errors.loadItemFailed'));
       }
     }
 
@@ -92,8 +94,8 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
 
       const lookup = () => {
         let objToLookIn = finalRawData;
-        for(const pathElem of dataPathSplit) {
-          if(objToLookIn[pathElem] !== undefined && objToLookIn[pathElem] !== null) {
+        for (const pathElem of dataPathSplit) {
+          if (objToLookIn[pathElem] !== undefined && objToLookIn[pathElem] !== null) {
             objToLookIn = objToLookIn[pathElem];
           } else {
             return undefined;
@@ -180,17 +182,17 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
         if (Array.isArray(field.value)) return field.value.length === 0;
         return false;
       }
-      
+
       // Replace the validation code with:
       if (field.required && field.type !== 'boolean' && isFieldValueEmpty(field)) {
-        validationError = 'Please fill up all required fields.';
+        validationError = t('forms.errors.requiredFields');
       }
 
       if (dataHelpers.checkIfFieldIsObject(field) && field.value) {
         try {
           finalObject[field.name] = JSON.parse(field.value);
         } catch (e) {
-          validationError = `Invalid JSON for field "${field.name}".`;
+          validationError = t('forms.errors.invalidJson', { field: field.name });
         }
       }
 
@@ -248,7 +250,7 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
   function shouldFieldBeVisible(field: IConfigInputField, fields: IConfigInputField[]): boolean {
     if (!field.showFieldWhen) return true;
     if (typeof field.showFieldWhen !== 'function') {
-      console.warn('showFieldWhen must be a function');
+      console.warn(t('common.warnings.showFieldWhenFunction'));
       return true;
     }
     return field.showFieldWhen(fields);
@@ -287,7 +289,9 @@ export const FormPopup = withAppContext(({ context, title, successMessage, field
                   })
                 }
                 <div className="buttons-wrapper center">
-                  <Button type="submit" onClick={submitForm} >{customLabels?.buttons?.submitItem || 'Submit'}</Button>
+                  <Button type="submit" onClick={submitForm}>
+                    {customLabels?.buttons?.submitItem || t('buttons.submitItem')}
+                  </Button>
                 </div>
               </form>
           }

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
 import { orderBy } from "natural-orderby";
 import { toast } from "react-toastify";
 import { Multiselect } from "multiselect-react-dropdown";
@@ -16,6 +15,7 @@ import { dataHelpers } from "../../helpers/data.helpers";
 
 import "./formRow.scss";
 import "jsoneditor-react/es/editor.min.css";
+import { usePageTranslation } from "../../hooks/usePageTranslation";
 
 const { JsonEditor } = require("jsoneditor-react");
 
@@ -42,13 +42,13 @@ export const FormRow = withAppContext(
     const [optionSources, setOptionSources] = useState<any>({});
     const [originalOptions, setOriginalOptions] = useState<any>({});
     const { httpService, activePage, config } = context;
-    const { t } = useTranslation();
+    const { translatePage } = usePageTranslation(activePage?.id);
     const pageHeaders: any = activePage?.requestHeaders || {};
     const customLabels: ICustomLabels | undefined = {
       ...config?.customLabels,
       ...activePage?.customLabels,
     };
-    const clearLabel = customLabels?.buttons?.clearInput || t('buttons.clearInput');
+    const clearLabel = customLabels?.buttons?.clearInput || translatePage('buttons.clearInput');
 
     const getFieldLabel = () => {
       // Try to get label in this order:
@@ -61,7 +61,7 @@ export const FormRow = withAppContext(
 
       const pageId = activePage?.id;
       if (pageId && field.name) {
-        const i18nLabel = t(`pages.${pageId}.fields.${field.originalName}.label`, { returnNull: true, });
+        const i18nLabel = translatePage(`fields.${field.originalName}.label`, { returnNull: true, });
         if (i18nLabel) {
           return i18nLabel;
         }
@@ -117,7 +117,7 @@ export const FormRow = withAppContext(
               display:
                 displayPath && option[displayPath]
                   ? option[displayPath]
-                  : t('forms.defaultOption', { index: idx + 1 }),
+                  : translatePage('forms.defaultOption', { index: idx + 1 }),
               value:
                 valuePath && option[valuePath] ? option[valuePath] : `${idx}`,
               sourceItem: option,
@@ -234,7 +234,7 @@ export const FormRow = withAppContext(
             loadOptionSourceFromRemote(field.name, optionSource);
             return (
               <select {...inputProps()}>
-                <option>{t('forms.loading')}</option>
+                <option>{translatePage('forms.loading')}</option>
               </select>
             );
           }
@@ -256,7 +256,7 @@ export const FormRow = withAppContext(
 
           return (
             <select {...inputProps()}>
-              <option>{t('forms.select')}</option>
+              <option>{translatePage('forms.select')}</option>
               {finalOptions.map((option, idx) => {
                 const key = `option_${idx}_`;
                 if (typeof option !== "object") {
@@ -284,7 +284,7 @@ export const FormRow = withAppContext(
             loadOptionSourceFromRemote(field.name, optionSource);
             return (
               <select {...inputProps()}>
-                <option>{t('forms.loading')}</option>
+                <option>{translatePage('forms.loading')}</option>
               </select>
             );
           }
@@ -422,7 +422,7 @@ export const FormRow = withAppContext(
           return (
             <textarea
               {...inputProps(
-                customLabels?.placeholders?.text || t('placeholders.text')
+                customLabels?.placeholders?.text || translatePage('placeholders.text')
               )}
             ></textarea>
           );
@@ -431,7 +431,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="number"
-              {...inputProps(customLabels?.placeholders?.number || t('placeholders.number'))}
+              {...inputProps(customLabels?.placeholders?.number || translatePage('placeholders.number'))}
               onChange={(e) =>
                 changeCallback(field.name, e.target.valueAsNumber)
               }
@@ -441,21 +441,21 @@ export const FormRow = withAppContext(
           return (
             <input
               type="color"
-              {...inputProps(customLabels?.placeholders?.color || t('placeholders.color'))}
+              {...inputProps(customLabels?.placeholders?.color || translatePage('placeholders.color'))}
             />
           );
         case "email":
           return (
             <input
               type="email"
-              {...inputProps(customLabels?.placeholders?.email || t('placeholders.email'))}
+              {...inputProps(customLabels?.placeholders?.email || translatePage('placeholders.email'))}
             />
           );
         case "password":
           return (
             <input
               type="password"
-              {...inputProps(customLabels?.placeholders?.password || t('placeholders.password'))}
+              {...inputProps(customLabels?.placeholders?.password || translatePage('placeholders.password'))}
             />
           );
         case "hidden":
@@ -468,7 +468,7 @@ export const FormRow = withAppContext(
               placeholder={
                 field.placeholder ||
                 customLabels?.placeholders?.file ||
-                t('placeholders.file')
+                translatePage('placeholders.file')
               }
               name={field.name || "file"}
               disabled={field.readonly}
@@ -481,7 +481,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="date"
-              {...inputProps(customLabels?.placeholders?.date || t('placeholders.date'))}
+              {...inputProps(customLabels?.placeholders?.date || translatePage('placeholders.date'))}
             />
           );
         case "text":
@@ -489,7 +489,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="text"
-              {...inputProps(customLabels?.placeholders?.text || t('placeholders.text'))}
+              {...inputProps(customLabels?.placeholders?.text || translatePage('placeholders.text'))}
             />
           );
       }
@@ -511,7 +511,7 @@ export const FormRow = withAppContext(
             <i
               title={clearLabel}
               onClick={() => onChange(field.name, "", true)}
-              aria-label={t('aria.clear')}
+              aria-label={translatePage('aria.clear')}
               className="clear-input fa fa-times"
             ></i>
           )}

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { orderBy } from "natural-orderby";
 import { toast } from "react-toastify";
 import { Multiselect } from "multiselect-react-dropdown";
@@ -41,13 +42,33 @@ export const FormRow = withAppContext(
     const [optionSources, setOptionSources] = useState<any>({});
     const [originalOptions, setOriginalOptions] = useState<any>({});
     const { httpService, activePage, config } = context;
+    const { t } = useTranslation();
     const pageHeaders: any = activePage?.requestHeaders || {};
     const customLabels: ICustomLabels | undefined = {
       ...config?.customLabels,
       ...activePage?.customLabels,
     };
-    // const addArrayItemLabel = customLabels?.buttons?.addArrayItem || 'Add Item';
-    const clearLabel = customLabels?.buttons?.clearInput || "Clear";
+    const clearLabel = customLabels?.buttons?.clearInput || t('buttons.clearInput');
+
+    const getFieldLabel = () => {
+      // Try to get label in this order:
+      // 1. Field's label property (backward compatibility)
+      // 2. i18n field label from current page
+      // 3. Field's original name
+      if (field.label) {
+        return field.label;
+      }
+
+      const pageId = activePage?.id;
+      if (pageId && field.name) {
+        const i18nLabel = t(`pages.${pageId}.fields.${field.originalName}.label`, { returnNull: true, });
+        if (i18nLabel) {
+          return i18nLabel;
+        }
+      }
+
+      return field.originalName;
+    };
 
     async function loadOptionSourceFromRemote(
       fieldName: string,
@@ -75,10 +96,7 @@ export const FormRow = withAppContext(
           headers: Object.assign({}, pageHeaders, requestHeaders || {}),
         });
 
-        const extractedData = dataHelpers.extractDataByDataPath(
-          result,
-          dataPath
-        );
+        const extractedData = dataHelpers.extractDataByDataPath(result, dataPath);
 
         if (!extractedData || !extractedData.length) {
           throw new Error(
@@ -99,7 +117,7 @@ export const FormRow = withAppContext(
               display:
                 displayPath && option[displayPath]
                   ? option[displayPath]
-                  : `Option ${idx + 1}`,
+                  : t('forms.defaultOption', { index: idx + 1 }),
               value:
                 valuePath && option[valuePath] ? option[valuePath] : `${idx}`,
               sourceItem: option,
@@ -216,7 +234,7 @@ export const FormRow = withAppContext(
             loadOptionSourceFromRemote(field.name, optionSource);
             return (
               <select {...inputProps()}>
-                <option>-- Loading Options... --</option>
+                <option>{t('forms.loading')}</option>
               </select>
             );
           }
@@ -238,7 +256,7 @@ export const FormRow = withAppContext(
 
           return (
             <select {...inputProps()}>
-              <option>-- Select --</option>
+              <option>{t('forms.select')}</option>
               {finalOptions.map((option, idx) => {
                 const key = `option_${idx}_`;
                 if (typeof option !== "object") {
@@ -266,7 +284,7 @@ export const FormRow = withAppContext(
             loadOptionSourceFromRemote(field.name, optionSource);
             return (
               <select {...inputProps()}>
-                <option>-- Loading Options... --</option>
+                <option>{t('forms.loading')}</option>
               </select>
             );
           }
@@ -404,7 +422,7 @@ export const FormRow = withAppContext(
           return (
             <textarea
               {...inputProps(
-                customLabels?.placeholders?.text || "Enter text..."
+                customLabels?.placeholders?.text || t('placeholders.text')
               )}
             ></textarea>
           );
@@ -413,7 +431,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="number"
-              {...inputProps(customLabels?.placeholders?.number || "0")}
+              {...inputProps(customLabels?.placeholders?.number || t('placeholders.number'))}
               onChange={(e) =>
                 changeCallback(field.name, e.target.valueAsNumber)
               }
@@ -423,27 +441,21 @@ export const FormRow = withAppContext(
           return (
             <input
               type="color"
-              {...inputProps(
-                customLabels?.placeholders?.color || "Enter color..."
-              )}
+              {...inputProps(customLabels?.placeholders?.color || t('placeholders.color'))}
             />
           );
         case "email":
           return (
             <input
               type="email"
-              {...inputProps(
-                customLabels?.placeholders?.email || "Enter email..."
-              )}
+              {...inputProps(customLabels?.placeholders?.email || t('placeholders.email'))}
             />
           );
         case "password":
           return (
             <input
               type="password"
-              {...inputProps(
-                customLabels?.placeholders?.password || "Enter password..."
-              )}
+              {...inputProps(customLabels?.placeholders?.password || t('placeholders.password'))}
             />
           );
         case "hidden":
@@ -456,7 +468,7 @@ export const FormRow = withAppContext(
               placeholder={
                 field.placeholder ||
                 customLabels?.placeholders?.file ||
-                "Select file..."
+                t('placeholders.file')
               }
               name={field.name || "file"}
               disabled={field.readonly}
@@ -469,9 +481,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="date"
-              {...inputProps(
-                customLabels?.placeholders?.date || "Enter date..."
-              )}
+              {...inputProps(customLabels?.placeholders?.date || t('placeholders.date'))}
             />
           );
         case "text":
@@ -479,9 +489,7 @@ export const FormRow = withAppContext(
           return (
             <input
               type="text"
-              {...inputProps(
-                customLabels?.placeholders?.text || "Enter text..."
-              )}
+              {...inputProps(customLabels?.placeholders?.text || t('placeholders.text'))}
             />
           );
       }
@@ -491,7 +499,7 @@ export const FormRow = withAppContext(
       <div className={`form-row ${direction || "row"}`}>
         {field.type !== "hidden" && (
           <label>
-            {field.label || field.originalName}
+            {getFieldLabel()}
             {field.required ? " *" : ""}
           </label>
         )}
@@ -503,7 +511,7 @@ export const FormRow = withAppContext(
             <i
               title={clearLabel}
               onClick={() => onChange(field.name, "", true)}
-              aria-label="Clear"
+              aria-label={t('aria.clear')}
               className="clear-input fa fa-times"
             ></i>
           )}

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { NavLink, useHistory } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
 import { IAppContext } from '../app.context';
 import { withAppContext } from '../withContext/withContext.comp';
 import { Button } from '../button/button.comp';
@@ -15,16 +15,16 @@ interface IProps {
 const NavigationComp = ({ context: { config, authService, loggedInUsername, setLoggedInUsername } }: IProps) => {
   const [isOpened, setIsOpened] = useState<boolean>(false);
   const { replace } = useHistory();
-  const { t } = useTranslation();
+  const { translate } = usePageTranslation();
 
   async function logout() {
     try {
       await authService.logout();
       setLoggedInUsername(null);
-      toast.info(t('auth.logoutSuccess'));
+      toast.info(translate('auth.logoutSuccess'));
       replace('/login');
     } catch (error) {
-      toast.error(t('auth.logoutFailed'));
+      toast.error(translate('auth.logoutFailed'));
     }
   }
 
@@ -42,7 +42,7 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         <div className="app-nav-links">
           {
             (config?.pages || []).map((page, idx) => {
-              const pageName = t(`pages.${page.id}.title`) || page.name;
+              const pageName = translate(`pages.${page.id}.title`) || page.name;
               return page?.customLink ?
                 <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
@@ -53,10 +53,10 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         {!!loggedInUsername && (
           <div className="app-nav-logout">
             <NavLink to="/change-password" className="change-password-link">
-              {t('auth.changePassword')}
+              {translate('auth.changePassword')}
             </NavLink>
             <NavLink to="/login" onClick={logout} className="logout-link">
-              {t('auth.logout')} ({loggedInUsername})
+              {translate('auth.logout')} ({loggedInUsername})
             </NavLink>
           </div>
         )}

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -42,7 +42,7 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         <div className="app-nav-links">
           {
             (config?.pages || []).map((page, idx) => {
-              const pageName = translate(`pages.${page.id}.title`) || page.name;
+              const pageName = translate(`pages.${page.id}.title`) || page.id;
               return page?.customLink ?
                 <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { NavLink, useHistory } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { IAppContext } from '../app.context';
 import { withAppContext } from '../withContext/withContext.comp';
 import { Button } from '../button/button.comp';
@@ -14,15 +15,16 @@ interface IProps {
 const NavigationComp = ({ context: { config, authService, loggedInUsername, setLoggedInUsername } }: IProps) => {
   const [isOpened, setIsOpened] = useState<boolean>(false);
   const { replace } = useHistory();
+  const { t } = useTranslation();
 
   async function logout() {
     try {
       await authService.logout();
       setLoggedInUsername(null);
-      toast.info('Logged out successfully');
+      toast.info(t('auth.logoutSuccess'));
       replace('/login');
     } catch (error) {
-      toast.error('Logout failed');
+      toast.error(t('auth.logoutFailed'));
     }
   }
 
@@ -40,20 +42,21 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         <div className="app-nav-links">
           {
             (config?.pages || []).map((page, idx) => {
+              const pageName = t(`pages.${page.id}.title`) || page.name;
               return page?.customLink ?
-                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{page.name}</a> :
+                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
-                  onClick={() => setIsOpened(false)}>{page.name}</NavLink>
+                  onClick={() => setIsOpened(false)}>{pageName}</NavLink>
             })
           }
         </div>
         {!!loggedInUsername && (
           <div className="app-nav-logout">
             <NavLink to="/change-password" className="change-password-link">
-              Change Password
+              {t('auth.changePassword')}
             </NavLink>
             <NavLink to="/login" onClick={logout} className="logout-link">
-              Logout ({loggedInUsername})
+              {t('auth.logout')} ({loggedInUsername})
             </NavLink>
           </div>
         )}

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams, useHistory } from "react-router-dom";
 import * as QueryString from "query-string";
 import { toast } from "react-toastify";
@@ -51,7 +52,7 @@ interface IProps {
 
 interface IPopupProps {
   type: "add" | "update" | "action";
-  title: string;
+  title: string | undefined;
   successMessage: string;
   config: IConfigPostMethod | IConfigPutMethod;
   submitCallback: (body: any, containFiles: boolean) => void;
@@ -185,21 +186,22 @@ const PageComp = ({ context }: IProps) => {
     ...config?.customLabels,
     ...activePage?.customLabels,
   };
-  const addItemLabel = customLabels?.buttons?.addItem || "+ Add Item";
-  const addItemFormTitle = customLabels?.formTitles?.addItem || "Add Item";
-  const editItemFormTitle = customLabels?.formTitles?.editItem || "Update Item";
+  const { t } = useTranslation();
+  const addItemLabel = customLabels?.buttons?.addItem || t('buttons.addItem');
+  const addItemFormTitle = customLabels?.formTitles?.addItem || t('formTitles.addItem');
+  const editItemFormTitle = customLabels?.formTitles?.editItem || t('formTitles.editItem');
   const addItemSuccessMessage = customLabels?.successMessages?.addItem !== undefined
     ? customLabels.successMessages.addItem
-    : "Item added successfully";
+    : t('successMessages.addItem');
   const editItemSuccessMessage = customLabels?.successMessages?.editItem !== undefined
     ? customLabels.successMessages.editItem
-    : "Item updated successfully";
+    : t('successMessages.editItem');
   const deleteItemSuccessMessage = customLabels?.successMessages?.deleteItem !== undefined
     ? customLabels.successMessages.deleteItem
-    : "Item deleted successfully";
+    : t('successMessages.deleteItem');
   const customActionSuccessMessage = customLabels?.successMessages?.customActions !== undefined
     ? customLabels.successMessages.customActions
-    : "Action performed successfully";
+    : t('successMessages.customActions');
   const { initQueryParams, initialPagination } =
     buildInitQueryParamsAndPaginationState(
       getAllConfig?.queryParams || [],
@@ -958,8 +960,8 @@ const PageComp = ({ context }: IProps) => {
     <div className="app-page">
       <header className="app-page-header">
         <hgroup>
-          <h2>{activePage?.name}</h2>
-          {activePage?.description && <h4>{activePage?.description}</h4>}
+          <h2>{t(`pages.${page}.title`) || activePage?.name} </h2>
+          <h4>{t(`pages.${page}.description`) || activePage?.description}</h4>
         </hgroup>
         {postConfig && (
           <Button

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { usePageTranslation } from "../../hooks/usePageTranslation";
 import { useParams, useHistory } from "react-router-dom";
 import * as QueryString from "query-string";
 import { toast } from "react-toastify";
@@ -186,22 +186,22 @@ const PageComp = ({ context }: IProps) => {
     ...config?.customLabels,
     ...activePage?.customLabels,
   };
-  const { t } = useTranslation();
-  const addItemLabel = customLabels?.buttons?.addItem || t('buttons.addItem');
-  const addItemFormTitle = customLabels?.formTitles?.addItem || t('formTitles.addItem');
-  const editItemFormTitle = customLabels?.formTitles?.editItem || t('formTitles.editItem');
+  const { translatePage } = usePageTranslation(page);
+  const addItemLabel = customLabels?.buttons?.addItem || translatePage('buttons.addItem');
+  const addItemFormTitle = customLabels?.formTitles?.addItem || translatePage('formTitles.addItem');
+  const editItemFormTitle = customLabels?.formTitles?.editItem || translatePage('formTitles.editItem');
   const addItemSuccessMessage = customLabels?.successMessages?.addItem !== undefined
     ? customLabels.successMessages.addItem
-    : t('successMessages.addItem');
+    : translatePage('successMessages.addItem');
   const editItemSuccessMessage = customLabels?.successMessages?.editItem !== undefined
     ? customLabels.successMessages.editItem
-    : t('successMessages.editItem');
+    : translatePage('successMessages.editItem');
   const deleteItemSuccessMessage = customLabels?.successMessages?.deleteItem !== undefined
     ? customLabels.successMessages.deleteItem
-    : t('successMessages.deleteItem');
+    : translatePage('successMessages.deleteItem');
   const customActionSuccessMessage = customLabels?.successMessages?.customActions !== undefined
     ? customLabels.successMessages.customActions
-    : t('successMessages.customActions');
+    : translatePage('successMessages.customActions');
   const { initQueryParams, initialPagination } =
     buildInitQueryParamsAndPaginationState(
       getAllConfig?.queryParams || [],
@@ -960,8 +960,8 @@ const PageComp = ({ context }: IProps) => {
     <div className="app-page">
       <header className="app-page-header">
         <hgroup>
-          <h2>{t(`pages.${page}.title`) || activePage?.name} </h2>
-          <h4>{t(`pages.${page}.description`) || activePage?.description}</h4>
+          <h2>{translatePage('title') || activePage?.name} </h2>
+          <h4>{translatePage('description') || activePage?.description}</h4>
         </hgroup>
         {postConfig && (
           <Button

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -984,6 +984,7 @@ const PageComp = ({ context }: IProps) => {
       {openedPopup && (
         <FormPopup
           title={openedPopup.title}
+          type={openedPopup.type}
           successMessage={openedPopup.successMessage}
           closeCallback={closeFormPopup}
           submitCallback={openedPopup.submitCallback}

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -486,9 +486,7 @@ const PageComp = ({ context }: IProps) => {
   }
 
   async function deleteItem(item: any) {
-    const approved: boolean = window.confirm(
-      "Are you sure you want to delete this item?"
-    );
+    const approved: boolean = window.confirm(translatePage('common.confirmDelete'));
 
     if (!approved) {
       return;

--- a/src/components/pagination/pagination.comp.tsx
+++ b/src/components/pagination/pagination.comp.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ICustomLabels } from '../../common/models/config.model';
 import { IPaginationState } from '../../common/models/states.model';
 import { Button } from '../button/button.comp';
@@ -15,15 +16,24 @@ interface IProps {
 }
 
 export const Pagination = ({ callbacks, pagination, customLabels }: IProps) => {
-  const previousTitle = customLabels?.pagination?.previousPageTitle || 'Previous page';
-  const nextTitle = customLabels?.pagination?.nextPageTitle || 'Next page';
+  const { t } = useTranslation();
+  const previousTitle = customLabels?.pagination?.previousPageTitle || t('pagination.previousPage');
+  const nextTitle = customLabels?.pagination?.nextPageTitle || t('pagination.nextPage');
   return (
     <div className="pagination-wrapper">
-      <Button disabled={!pagination.hasPreviousPage} onClick={() => callbacks.previousPage()} title={previousTitle}>
-        <i className="fa fa-arrow-left" aria-hidden="true"></i>
+      <Button 
+        disabled={!pagination.hasPreviousPage} 
+        onClick={() => callbacks.previousPage()} 
+        title={previousTitle}
+      >
+        <i className="fa fa-arrow-left" aria-hidden="true" />
       </Button>
-      <Button disabled={!pagination.hasNextPage} onClick={() => callbacks.nextPage()} title={nextTitle}>
-        <i className="fa fa-arrow-right" aria-hidden="true" ></i>
+      <Button 
+        disabled={!pagination.hasNextPage} 
+        onClick={() => callbacks.nextPage()} 
+        title={nextTitle}
+      >
+        <i className="fa fa-arrow-right" aria-hidden="true" />
       </Button>
     </div>
   );

--- a/src/components/pagination/pagination.comp.tsx
+++ b/src/components/pagination/pagination.comp.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
 import { ICustomLabels } from '../../common/models/config.model';
+import { IAppContext } from '../app.context';
+import { withAppContext } from '../withContext/withContext.comp';
 import { IPaginationState } from '../../common/models/states.model';
 import { Button } from '../button/button.comp';
 
 import './pagination.scss';
 
 interface IProps {
-  pagination: IPaginationState
+  context: IAppContext;
+  pagination: IPaginationState;
   callbacks: {
-    previousPage: () => void,
-    nextPage: () => void,
-  }
-  customLabels?: ICustomLabels
+    previousPage: () => void;
+    nextPage: () => void;
+  };
+  customLabels?: ICustomLabels;
 }
 
-export const Pagination = ({ callbacks, pagination, customLabels }: IProps) => {
-  const { t } = useTranslation();
-  const previousTitle = customLabels?.pagination?.previousPageTitle || t('pagination.previousPage');
-  const nextTitle = customLabels?.pagination?.nextPageTitle || t('pagination.nextPage');
+const PaginationComp = ({ context, callbacks, pagination, customLabels }: IProps) => {
+  const { translatePage } = usePageTranslation(context.activePage?.id);
+  const previousTitle = customLabels?.pagination?.previousPageTitle || translatePage('pagination.previousPage');
+  const nextTitle = customLabels?.pagination?.nextPageTitle || translatePage('pagination.nextPage');
+
   return (
     <div className="pagination-wrapper">
       <Button 
@@ -38,3 +42,5 @@ export const Pagination = ({ callbacks, pagination, customLabels }: IProps) => {
     </div>
   );
 };
+
+export const Pagination = withAppContext(PaginationComp);

--- a/src/components/popup/popup.comp.tsx
+++ b/src/components/popup/popup.comp.tsx
@@ -1,11 +1,14 @@
 import React, { Component, RefObject, ReactChild } from 'react';
 import ReactDOM from 'react-dom';
-import { useTranslation } from 'react-i18next';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
 
 import './popup.scss';
 import { ICustomLabels } from '../../common/models/config.model';
+import { IAppContext } from '../app.context';
+import { withAppContext } from '../withContext/withContext.comp';
 
-interface IPopupProps {
+interface IProps {
+  context: IAppContext;
   className?: string;
   style?: any;
   show: boolean;
@@ -43,10 +46,10 @@ class PortalPopup extends Component {
   }
 }
 
-export const Popup = ({ className, style, show, closeCallback, children, refCallback, customLabels }: IPopupProps) => {
-  const { t } = useTranslation();
+const PopupComp = ({ context, className, style, show, closeCallback, children, refCallback, customLabels }: IProps) => {
+  const { translatePage } = usePageTranslation(context.activePage?.id);
   const finalStyle: any = Object.assign({}, { display: show ? 'block' : 'none' }, style || {});
-  const closeLabel = customLabels?.buttons?.closeForm || t('buttons.closeForm');
+  const closeLabel = customLabels?.buttons?.closeForm || translatePage('buttons.closeForm');
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (show && e.keyCode === 27) {
@@ -73,7 +76,7 @@ export const Popup = ({ className, style, show, closeCallback, children, refCall
                 title={closeLabel}
                 className="close-popup" 
                 onClick={(e: any) => closeCallback(e)}
-                aria-label={t('aria.close')}
+                aria-label={translatePage('aria.close')}
               >
                 <i className="fa fa-times" aria-hidden="true"></i>
               </button>
@@ -84,3 +87,5 @@ export const Popup = ({ className, style, show, closeCallback, children, refCall
     </PortalPopup>
   );
 };
+
+export const Popup = withAppContext(PopupComp);

--- a/src/components/popup/popup.comp.tsx
+++ b/src/components/popup/popup.comp.tsx
@@ -1,17 +1,18 @@
 import React, { Component, RefObject, ReactChild } from 'react';
 import ReactDOM from 'react-dom';
+import { useTranslation } from 'react-i18next';
 
 import './popup.scss';
 import { ICustomLabels } from '../../common/models/config.model';
 
 interface IPopupProps {
-  className?: string
-  style?: any
-  show: boolean
-  closeCallback: any
-  children: ReactChild
-  refCallback?: string | ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined
-  customLabels?: ICustomLabels
+  className?: string;
+  style?: any;
+  show: boolean;
+  closeCallback: any;
+  children: ReactChild;
+  refCallback?: string | ((instance: HTMLDivElement | null) => void) | RefObject<HTMLDivElement> | null | undefined;
+  customLabels?: ICustomLabels;
 }
 
 let portalRoot: HTMLDivElement = document.getElementById('popup-portal') as HTMLDivElement;
@@ -26,7 +27,6 @@ class PortalPopup extends Component {
 
   constructor(props: any) {
     super(props);
-
     this.el = document.createElement('div');
   }
 
@@ -43,43 +43,44 @@ class PortalPopup extends Component {
   }
 }
 
-export class Popup extends Component<IPopupProps> {
-  render() {
-    const style: any = Object.assign({}, { display: this.props.show ? 'block' : 'none' }, this.props.style || {});
-    const closeLabel = this.props.customLabels?.buttons?.closeForm || 'Close';
+export const Popup = ({ className, style, show, closeCallback, children, refCallback, customLabels }: IPopupProps) => {
+  const { t } = useTranslation();
+  const finalStyle: any = Object.assign({}, { display: show ? 'block' : 'none' }, style || {});
+  const closeLabel = customLabels?.buttons?.closeForm || t('buttons.closeForm');
 
-    return (
-      <PortalPopup>
-        {
-          this.props.show ?
-            <div className={`popup ${this.props.className || ''}`} style={style}>
-              <div className="overlay" onClick={(e: any) => this.props.closeCallback(e)}></div>
-              <div className="popup-content" ref={this.props.refCallback}>
-                {this.props.children}
-                <button title={closeLabel} className="close-popup" onClick={(e: any) => this.props.closeCallback(e)}>
-                  <i className="fa fa-times" aria-hidden="true"></i>
-                </button>
-              </div>
-            </div> :
-            null
-        }
-      </PortalPopup>
-    );
-  }
-
-  componentDidMount() {
-    document.addEventListener('keydown', this._handleKeyDown.bind(this));
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this._handleKeyDown.bind(this));
-  }
-
-  _handleKeyDown = (e: KeyboardEvent) => {
-    const { show, closeCallback } = this.props;
-
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (show && e.keyCode === 27) {
       closeCallback(e);
     }
-  }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [show]);
+
+  return (
+    <PortalPopup>
+      {
+        show ?
+          <div className={`popup ${className || ''}`} style={finalStyle}>
+            <div className="overlay" onClick={(e: any) => closeCallback(e)}></div>
+            <div className="popup-content" ref={refCallback}>
+              {children}
+              <button 
+                title={closeLabel}
+                className="close-popup" 
+                onClick={(e: any) => closeCallback(e)}
+                aria-label={t('aria.close')}
+              >
+                <i className="fa fa-times" aria-hidden="true"></i>
+              </button>
+            </div>
+          </div> :
+          null
+      }
+    </PortalPopup>
+  );
 };

--- a/src/components/queryParams/queryParams.comp.tsx
+++ b/src/components/queryParams/queryParams.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { IConfigInputField, IConfigPagination } from '../../common/models/config.model';
 import { FormRow } from '../formRow/formRow.comp';
@@ -15,6 +16,7 @@ interface IProps {
 
 export const QueryParams = ({ initialParams, paginationConfig, submitCallback }: IProps) => {
   const [queryParams, setQueryParams] = useState<IConfigInputField[]>(initialParams);
+  const { t } = useTranslation();
 
   function submit(e?: any) {
     if (e) {
@@ -53,9 +55,10 @@ export const QueryParams = ({ initialParams, paginationConfig, submitCallback }:
     return <React.Fragment></React.Fragment>;
   }
 
+  
   return (
     <section className="query-params-form">
-      <h5>Query Params:</h5>
+      <h5>{t('forms.queryParams.title')}</h5>
       <form onSubmit={submit}>
         {
           queryParams.map((queryParam, idx) => {
@@ -69,7 +72,7 @@ export const QueryParams = ({ initialParams, paginationConfig, submitCallback }:
             );
           })
         }
-        <Button type="submit" onClick={submit}>Submit</Button>
+        <Button type="submit" onClick={submit}>{t('buttons.submit')}</Button>
       </form>
     </section>
   );

--- a/src/components/queryParams/queryParams.comp.tsx
+++ b/src/components/queryParams/queryParams.comp.tsx
@@ -74,7 +74,7 @@ const QueryParamsComp = ({ context, initialParams, paginationConfig, submitCallb
             );
           })
         }
-        <Button type="submit" onClick={submit}>{translatePage('buttons.submit')}</Button>
+        <Button type="submit" onClick={submit}>{translatePage('buttons.submitQuery')}</Button>
       </form>
     </section>
   );

--- a/src/components/queryParams/queryParams.comp.tsx
+++ b/src/components/queryParams/queryParams.comp.tsx
@@ -1,24 +1,27 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { IConfigInputField, IConfigPagination } from '../../common/models/config.model';
 import { FormRow } from '../formRow/formRow.comp';
 import { Button } from '../button/button.comp';
+import { usePageTranslation } from '../../hooks/usePageTranslation';
+import { withAppContext } from '../withContext/withContext.comp';
+import { IAppContext } from '../app.context';
+import { dataHelpers } from "../../helpers/data.helpers";
 
 import './queryParams.scss';
-import {dataHelpers} from "../../helpers/data.helpers";
 
 interface IProps {
-  initialParams: IConfigInputField[]
-  paginationConfig?: IConfigPagination
-  submitCallback: (queryParams: IConfigInputField[], reset?: boolean) => void
+  context: IAppContext;
+  initialParams: IConfigInputField[];
+  paginationConfig?: IConfigPagination;
+  submitCallback: (queryParams: IConfigInputField[], reset?: boolean) => void;
 }
 
-export const QueryParams = ({ initialParams, paginationConfig, submitCallback }: IProps) => {
+const QueryParamsComp = ({ context, initialParams, paginationConfig, submitCallback }: IProps) => {
+  const { translatePage } = usePageTranslation(context.activePage?.id);
   const [queryParams, setQueryParams] = useState<IConfigInputField[]>(initialParams);
-  const { t } = useTranslation();
 
-  function submit(e?: any) {
+  function submit(e?: React.FormEvent) {
     if (e) {
       e.preventDefault();
     }
@@ -33,7 +36,7 @@ export const QueryParams = ({ initialParams, paginationConfig, submitCallback }:
   function formChanged(fieldName: string, value: any, submitAfterChange?: boolean) {
     const updatedQueryParams: IConfigInputField[] = [...queryParams];
 
-    dataHelpers.updateInputFieldFromFields(fieldName, value, updatedQueryParams)
+    dataHelpers.updateInputFieldFromFields(fieldName, value, updatedQueryParams);
 
     setQueryParams(updatedQueryParams);
 
@@ -55,10 +58,9 @@ export const QueryParams = ({ initialParams, paginationConfig, submitCallback }:
     return <React.Fragment></React.Fragment>;
   }
 
-  
   return (
     <section className="query-params-form">
-      <h5>{t('forms.queryParams.title')}</h5>
+      <h5>{translatePage('forms.queryParams.title')}</h5>
       <form onSubmit={submit}>
         {
           queryParams.map((queryParam, idx) => {
@@ -72,8 +74,10 @@ export const QueryParams = ({ initialParams, paginationConfig, submitCallback }:
             );
           })
         }
-        <Button type="submit" onClick={submit}>{t('buttons.submit')}</Button>
+        <Button type="submit" onClick={submit}>{translatePage('buttons.submit')}</Button>
       </form>
     </section>
   );
 };
+
+export const QueryParams = withAppContext(QueryParamsComp);

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { usePageTranslation } from "../../hooks/usePageTranslation";
 import InfiniteScroll from "react-infinite-scroll-component";
 
 import {
@@ -35,11 +35,11 @@ interface IProps {
 }
 
 export const Table = withAppContext(({ context, items, fields, pagination, callbacks, customActions, customLabels }: IProps) => {
-  const { t } = useTranslation();
-  const editLabel = customLabels?.buttons?.editItem || t('buttons.editItem');
-  const deleteLabel = customLabels?.buttons?.deleteItem || t('buttons.deleteItem');
+  const { translatePage } = usePageTranslation(context.activePage?.id);
+  const editLabel = customLabels?.buttons?.editItem || translatePage('buttons.editItem');
+  const deleteLabel = customLabels?.buttons?.deleteItem || translatePage('buttons.deleteItem');
   const actionColumnHeader =
-    customLabels?.tableColumnHeaders?.actions || t('common.actions');
+    customLabels?.tableColumnHeaders?.actions || translatePage('common.actions');
   const paginationCallbacks = {
     nextPage:
       callbacks.getNextPage ||
@@ -183,7 +183,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
                     }
                   }}
                 >
-                  {field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}
+                  {field.label || translatePage(`fields.${field.name}.label`) || field.name}
                 </th>
               );
             })}

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import InfiniteScroll from "react-infinite-scroll-component";
 
 import {
@@ -11,10 +12,13 @@ import { Button } from "../button/button.comp";
 import { InfiniteLoader } from "../infiniteLoader/infiniteLoader.comp";
 import { IPaginationState } from "../../common/models/states.model";
 import { Pagination } from "../pagination/pagination.comp";
+import { IAppContext } from "../app.context";
+import { withAppContext } from "../withContext/withContext.comp";
 
 import "./table.scss";
 
 interface IProps {
+  context: IAppContext;
   items: any[];
   pagination?: IPaginationState;
   callbacks: {
@@ -30,18 +34,12 @@ interface IProps {
   customLabels?: ICustomLabels;
 }
 
-export const Table = ({
-  items,
-  fields,
-  pagination,
-  callbacks,
-  customActions,
-  customLabels,
-}: IProps) => {
-  const editLabel = customLabels?.buttons?.editItem || "Edit";
-  const deleteLabel = customLabels?.buttons?.deleteItem || "Delete";
+export const Table = withAppContext(({ context, items, fields, pagination, callbacks, customActions, customLabels }: IProps) => {
+  const { t } = useTranslation();
+  const editLabel = customLabels?.buttons?.editItem || t('buttons.editItem');
+  const deleteLabel = customLabels?.buttons?.deleteItem || t('buttons.deleteItem');
   const actionColumnHeader =
-    customLabels?.tableColumnHeaders?.actions || "Actions";
+    customLabels?.tableColumnHeaders?.actions || t('common.actions');
   const paginationCallbacks = {
     nextPage:
       callbacks.getNextPage ||
@@ -133,7 +131,7 @@ export const Table = ({
           <div className="actions-wrapper">
             {callbacks.put && (
               <Button onClick={() => callbacks.put?.(item)} title={editLabel}>
-                <i className="fa fa-pencil-square-o" aria-hidden="true"></i>
+                <i className="fa fa-pencil-square-o" aria-hidden="true" />
               </Button>
             )}
             {customActions &&
@@ -185,7 +183,7 @@ export const Table = ({
                     }
                   }}
                 >
-                  {field.label || field.name}
+                  {field.label || t(`pages.${context.activePage?.id}.fields.${field.name}.label`) || field.name}
                 </th>
               );
             })}
@@ -233,4 +231,4 @@ export const Table = ({
       )}
     </div>
   );
-};
+});

--- a/src/hooks/usePageTranslation.ts
+++ b/src/hooks/usePageTranslation.ts
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+import { TFunction, TOptions, TFunctionResult } from 'i18next';
+
+/**
+ * Custom hook that extends useTranslation to support both global and page-specific translations
+ * @param pageId - The ID of the current page (optional)
+ * @returns Object with translation functions and i18n instance
+ */
+export const usePageTranslation = (pageId?: string) => {
+  const { t: baseT, i18n, ...rest } = useTranslation();
+
+  const translatePage = (key: string | string[], options?: TOptions | string): string => {
+    const translationOptions = typeof options === 'string' ? { defaultValue: options } : options;
+    
+    // Always use 'pages.<pageId>.' prefix for page translations
+    const namespaceKey = `pages.${pageId}.${key}`;
+    const pageTrans = baseT(namespaceKey, { ...(translationOptions || {}), returnNull: true });
+    
+    if (pageTrans !== null) {
+      return pageTrans;
+    }
+
+    // Fallback to global namespace
+    return baseT(`global.${key}`, translationOptions);
+  };
+
+  return {
+    translate: baseT,
+    translatePage: pageId ? (translatePage as TFunction) : baseT,
+    i18n,
+    ...rest
+  };
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,23 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import resourcesToBackend from 'i18next-resources-to-backend';
+
+i18n
+  .use(resourcesToBackend((language: string) => import(`./locales/${language}.json`)))
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['navigator'],
+    },
+    parseMissingKeyHandler: (key: string) => {
+      return null;
+    }
+  });
+
+export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/app';
 import * as serviceWorker from './serviceWorker';
@@ -6,7 +7,12 @@ import './i18n';
 
 import './index.scss';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+    <Suspense fallback="Loading...">
+        <App />
+    </Suspense>,
+    document.getElementById('root')
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/app';
 import * as serviceWorker from './serviceWorker';
+import './i18n';
 
 import './index.scss';
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,90 @@
+{
+  "aria": {
+    "clear": "Clear",
+    "close": "Close"
+  },
+  "auth": {
+    "changePassword": "Change Password",
+    "labels": {
+      "confirmPassword": "Confirm New Password",
+      "newPassword": "New Password",
+      "oldPassword": "Old Password",
+      "password": "Password",
+      "user": "User"
+    },
+    "loginFailed": "Login failed",
+    "logout": "Logout",
+    "logoutFailed": "Logout failed",
+    "logoutSuccess": "Logged out successfully",
+    "passwordChangeRequired": "Password change required",
+    "passwordChanged": "Password changed successfully",
+    "passwordChangeFailed": "Password change failed",
+    "passwordMismatch": "Confirmed password does not match"
+  },
+  "buttons": {
+    "addArrayItem": "Add Item",
+    "addItem": "+ Add Item",
+    "clearInput": "Clear",
+    "closeForm": "Close",
+    "deleteItem": "Delete",
+    "editItem": "Edit",
+    "submit": "Submit",
+    "submitItem": "Submit"
+  },
+  "common": {
+    "actions": "Actions",
+    "confirmDelete": "Are you sure you want to delete this item?",
+    "emptyResults": "Nothing to see here. Result is empty.",
+    "error": "Error",
+    "loading": "Loading...",
+    "success": "Success",
+    "warning": "Warning"
+  },
+  "filter": {
+    "searchPlaceholder": "Search...",
+    "title": "Filter:"
+  },
+  "forms": {
+    "defaultOption": "Option {index}",
+    "errors": {
+      "invalidJson": "Invalid JSON for field \"{field}\"",
+      "loadItemFailed": "Could not load single item's data",
+      "requiredFields": "Please fill up all required fields"
+    },
+    "loading": "Loading options...",
+    "queryParams": {
+      "title": "Query Params:"
+    },
+    "select": "-- Select --"
+  },
+  "formTitles": {
+    "addItem": "Add Item",
+    "editItem": "Edit Item"
+  },
+  "pagination": {
+    "itemsCount": "Showing :currentCountFrom-:currentCountTo out of :totalCount items",
+    "nextPage": "Next page",
+    "previousPage": "Previous page"
+  },
+  "placeholders": {
+    "array": "Enter JSON array...",
+    "color": "Enter color...",
+    "confirmPassword": "Confirm new password...",
+    "date": "Enter date...",
+    "email": "Enter email...",
+    "file": "Select file...",
+    "newPassword": "Enter new password...",
+    "number": "0",
+    "object": "Enter JSON...",
+    "oldPassword": "Enter old password...",
+    "password": "Enter password...",
+    "text": "Enter text...",
+    "user": "Enter user...."
+  },
+  "successMessages": {
+    "addItem": "Item added successfully",
+    "customActions": "Action completed successfully",
+    "deleteItem": "Item deleted successfully",
+    "editItem": "Item updated successfully"
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -41,8 +41,10 @@
       "closeForm": "Close",
       "deleteItem": "Delete",
       "editItem": "Edit",
-      "submit": "Submit",
-      "submitItem": "Submit"
+      "submitAction": "Submit",
+      "submitAdd": "Submit",
+      "submitUpdate": "Submit",
+      "submitQuery": "Submit"
     },
     "common": {
       "actions": "Actions",
@@ -100,7 +102,7 @@
   "pages": {
     "<example-page-id>": {
       "buttons": {
-        "submit": "<submit>"
+        "submitAdd": "<submit>"
       },
       "description": "<description>",
       "title": "<title>"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,6 +37,8 @@
     "emptyResults": "Nothing to see here. Result is empty.",
     "error": "Error",
     "loading": "Loading...",
+    "loadingConfiguration": "Loading configuration...",
+    "loadingConfigurationFailed": "Could not load configuration",
     "success": "Success",
     "warning": "Warning"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,8 +1,4 @@
 {
-  "aria": {
-    "clear": "Clear",
-    "close": "Close"
-  },
   "auth": {
     "changePassword": "Change Password",
     "labels": {
@@ -12,6 +8,7 @@
       "password": "Password",
       "user": "User"
     },
+    "login": "Login",
     "loginFailed": "Login failed",
     "logout": "Logout",
     "logoutFailed": "Logout failed",
@@ -19,74 +16,94 @@
     "passwordChangeRequired": "Password change required",
     "passwordChanged": "Password changed successfully",
     "passwordChangeFailed": "Password change failed",
-    "passwordMismatch": "Confirmed password does not match"
+    "passwordMismatch": "Confirmed password does not match",
+    "placeholders": {
+      "confirmPassword": "Confirm new password...",
+      "newPassword": "Enter new password...",
+      "oldPassword": "Enter old password...",
+      "password": "Enter password...",
+      "user": "Enter user...."
+    }
   },
-  "buttons": {
-    "addArrayItem": "Add Item",
-    "addItem": "+ Add Item",
-    "clearInput": "Clear",
-    "closeForm": "Close",
-    "deleteItem": "Delete",
-    "editItem": "Edit",
-    "submit": "Submit",
-    "submitItem": "Submit"
-  },
-  "common": {
-    "actions": "Actions",
-    "confirmDelete": "Are you sure you want to delete this item?",
-    "emptyResults": "Nothing to see here. Result is empty.",
-    "error": "Error",
-    "loading": "Loading...",
+  "configuration": {
     "loadingConfiguration": "Loading configuration...",
-    "loadingConfigurationFailed": "Could not load configuration",
-    "success": "Success",
-    "warning": "Warning"
+    "loadingConfigurationFailed": "Could not load configuration"
   },
-  "filter": {
-    "searchPlaceholder": "Search...",
-    "title": "Filter:"
-  },
-  "forms": {
-    "defaultOption": "Option {index}",
-    "errors": {
-      "invalidJson": "Invalid JSON for field \"{field}\"",
-      "loadItemFailed": "Could not load single item's data",
-      "requiredFields": "Please fill up all required fields"
+  "global": {
+    "aria": {
+      "clear": "Clear",
+      "close": "Close"
     },
-    "loading": "Loading options...",
-    "queryParams": {
-      "title": "Query Params:"
+    "buttons": {
+      "addArrayItem": "Add Item",
+      "addItem": "+ Add Item",
+      "clearInput": "Clear",
+      "closeForm": "Close",
+      "deleteItem": "Delete",
+      "editItem": "Edit",
+      "submit": "Submit",
+      "submitItem": "Submit"
     },
-    "select": "-- Select --"
+    "common": {
+      "actions": "Actions",
+      "confirmDelete": "Are you sure you want to delete this item?",
+      "emptyResults": "Nothing to see here. Result is empty.",
+      "error": "Error",
+      "loading": "Loading...",
+      "success": "Success",
+      "warning": "Warning"
+    },
+    "filter": {
+      "searchPlaceholder": "Search...",
+      "title": "Filter:"
+    },
+    "forms": {
+      "defaultOption": "Option {index}",
+      "errors": {
+        "invalidJson": "Invalid JSON for field \"{field}\"",
+        "loadItemFailed": "Could not load single item's data",
+        "requiredFields": "Please fill up all required fields"
+      },
+      "loading": "Loading options...",
+      "queryParams": {
+        "title": "Query Params:"
+      },
+      "select": "-- Select --"
+    },
+    "formTitles": {
+      "addItem": "Add Item",
+      "editItem": "Edit Item"
+    },
+    "pagination": {
+      "itemsCount": "Showing :currentCountFrom-:currentCountTo out of :totalCount items",
+      "nextPage": "Next page",
+      "previousPage": "Previous page"
+    },
+    "placeholders": {
+      "array": "Enter JSON array...",
+      "color": "Enter color...",
+      "date": "Enter date...",
+      "email": "Enter email...",
+      "file": "Select file...",
+      "number": "0",
+      "object": "Enter JSON...",
+      "password": "Enter password...",
+      "text": "Enter text..."
+    },
+    "successMessages": {
+      "addItem": "Item added successfully",
+      "customActions": "Action completed successfully",
+      "deleteItem": "Item deleted successfully",
+      "editItem": "Item updated successfully"
+    }
   },
-  "formTitles": {
-    "addItem": "Add Item",
-    "editItem": "Edit Item"
-  },
-  "pagination": {
-    "itemsCount": "Showing :currentCountFrom-:currentCountTo out of :totalCount items",
-    "nextPage": "Next page",
-    "previousPage": "Previous page"
-  },
-  "placeholders": {
-    "array": "Enter JSON array...",
-    "color": "Enter color...",
-    "confirmPassword": "Confirm new password...",
-    "date": "Enter date...",
-    "email": "Enter email...",
-    "file": "Select file...",
-    "newPassword": "Enter new password...",
-    "number": "0",
-    "object": "Enter JSON...",
-    "oldPassword": "Enter old password...",
-    "password": "Enter password...",
-    "text": "Enter text...",
-    "user": "Enter user...."
-  },
-  "successMessages": {
-    "addItem": "Item added successfully",
-    "customActions": "Action completed successfully",
-    "deleteItem": "Item deleted successfully",
-    "editItem": "Item updated successfully"
+  "pages": {
+    "<example-page-id>": {
+      "buttons": {
+        "submit": "<submit>"
+      },
+      "description": "<description>",
+      "title": "<title>"
+    }
   }
 }


### PR DESCRIPTION
References Issue #271

This pull request implements internalisation using the i18next library.
All labels are moved to the provided i18n file `en.json'.
This deprecates customLabel and page-specific labels like page.title / page.description and field.label.
For backwards compatibility, if these labels are defined in config.js, they will override the i18n files.
 