### PR TITLE
Add optional helptexts for fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Each **page** is an object and represents a resource in your API. It should have
 
 | Property | Type | Required? | Description |
 |----------------|--------------|-----|----------------------------------------------------------------|
-| name | `string` | true | The name of the page. This will be presented in the menu. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
+| name | `string` | true | The name of the page. This will be presented in the menu. For translation support, it's recommended to leave this empty and define it in the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | id | `string` | true | A unique identifier for the page. RESTool will use it to navigate between pages. |
-| description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
+| description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | requestHeaders | `object` | false | A list of key-value headers you wish to add to every request we're making. <br /><br /> For example: <br />``{ Authentication: 'SECRET_KEY', 'X-USER-ID': 'USER_ID' }``. |
 | methods | `object` | true | A list of all methods which are available in your RESTful API. |
 | customActions | `object[]` | false | A list of extra (non RESTful) endpoints available in your RESTful API. Specifically `customActions` is a list of PUT or POST method objects. <br /><br />Read more about custom actions [here](#custom-actions). |
@@ -653,7 +653,7 @@ The list of fields you want to present in the main view of the app. Each one is 
 |----------------|--------------|-----|----------------------------------------------------------------|
 | name | `string` | true | The property name of the field that contains the value in the API result. |
 | type | `string` | true | This will help RESTool to render the main view. See a list of available type below. |
-| label | `string` | false | A label that describes the field. Will be presented as table headers in the main view. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
+| label | `string` | false | A label that describes the field. Will be presented as table headers in the main view. For translation support, it's recommended to leave this empty and define it in the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | dataPath | `string` | false | Read more about dataPath [here](#data-path).
 | filterable | `boolean` | false | Set to `true` to enable a text control to do simple client-side filtering by values of this field. Can be specified for multiple fields. |
 | truncate | `boolean` | false | Causes long values to be truncated. By default, truncation is not enabled for fields. |

--- a/README.md
+++ b/README.md
@@ -687,6 +687,15 @@ Here's a list of available display field types:
 
 <br />
 
+#### Help text
+Help text provides additional context or instructions for fields in forms and tables. 
+Help text can be defined in your i18n language files under each page's namespace. The text appears differently depending on the layout:
+
+- In card layout: Displayed below the field name
+- In table layout: Shown when hovering over a help icon next to the field name
+
+To add help text for a field, define it in your language file under the page's fields namespace. See [Internationalization (i18n)](#internationalization-i18n) section.
+
 ### Input fields
 
 A list of fields you want us to send as the body of the request. Each one is an object and could have the following properties:

--- a/README.md
+++ b/README.md
@@ -16,33 +16,6 @@ The idea behind it is simple. Given the fact that each entity in your API has a 
 
 <br />
 
-## Table of Contents
-
-- [What's New in V2?](#whats-new-in-v2)
-- [Getting started](#getting-started)
-- [Configuration](#configuration)
-  - [Authorization](#auth-config)
-  - [Pages](#pages)
-  - [Methods](#methods)
-    - [`getAll` - additional properties](#getall---additional-properties)
-    - [`getSingle`](#getsingle)
-    - [`post`](#post)
-    - [`put` - additional properties](#put---additional-properties)
-    - [`delete`](#delete)
-  - [Pagination](#pagination)
-  - [Custom Actions](#custom-actions)
-  - [Custom Styles](#custom-styles)
-  - [Custom Labels](#custom-labels)
-  - [Display fields](#display-fields)
-  - [Input fields](#input-fields)
-  - [Logo Header](#logo-header)
-  - [Internationalization (i18n)](#internationalization-i18n)
-- [Development](#development)
-  - [Local Development](#local-development)
-  - [Consume from CDN](#consume-from-cdn)
-  - [Deploy](#deploy)
-- [Contributing](#contributing)
-
 ## What's New in V2?
 
 While RESTool originally was developed with Angular, we decided to rewrite it from scratch and move to **React**. The main reason we moved to React is the **community**. Since React is so popular we believe that choosing React over Angular will get a much wider **community support**.
@@ -119,7 +92,6 @@ The `auth` property allows you to configure authentication endpoints. It has the
 | logoutEndpoint | `string` | true | The endpoint to send the logout request to. | Request: `POST` <br> Response: `200 OK` |
 | userEndpoint | `string` | true | The endpoint to get the user data from. It should return a JSON object with the property `username`. | Request: `GET` <br> Response: `{ username: string }` |
 | changePasswordEndpoint | `string` | true | The endpoint to send password change requests to. | Request: `PUT { oldPassword: string, newPassword: string }` <br> Response: `200 OK` |
-| icons | `object` | false | Optional configuration for UI icons. Contains `changePassword` and `logout` properties that accept Font Awesome icon names. When not defined for an action, no icon will be shown. | Example: `{ changePassword: "retweet", logout: "sign-out" }` |
 
 Example auth configuration:
 ```json
@@ -166,8 +138,7 @@ Each **page** is an object and represents a resource in your API. It should have
 |----------------|--------------|-----|----------------------------------------------------------------|
 | name | `string` | true | The name of the page. This will be presented in the menu. For translation support, it's recommended to leave this empty and define it in the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | id | `string` | true | A unique identifier for the page. RESTool will use it to navigate between pages. |
-| description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
-| icon | `string` | false | Font Awesome icon name (without the 'fa-' prefix) to display next to the page name in navigation. For example: 'cog', 'user', 'key', etc. |
+| description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | requestHeaders | `object` | false | A list of key-value headers you wish to add to every request we're making. <br /><br /> For example: <br />``{ Authentication: 'SECRET_KEY', 'X-USER-ID': 'USER_ID' }``. |
 | methods | `object` | true | A list of all methods which are available in your RESTful API. |
 | customActions | `object[]` | false | A list of extra (non RESTful) endpoints available in your RESTful API. Specifically `customActions` is a list of PUT or POST method objects. <br /><br />Read more about custom actions [here](#custom-actions). |
@@ -191,7 +162,6 @@ Each method has the following common properties (which could be extended specifi
 |----------------|--------------|-----|----------------------------------------------------------------|
 | url | `string` | true | The url for making the request. The url could be either relative or absolute. If a ``baseUrl`` is defined then you should only provide a relative path. For example: ``/users/:id``. <br /><br />The url could contain parameters that will be extracted if needed. For example: ``https://website.com/users/:id`` - note that the parameter name in the url should match the one you're returning in your API. |
 | actualMethod | `string` ("get", "put", "post", "delete", "patch") | false | Since not everyone implements the RESTful standard, if you need to make a 'post' request in order to update an exiting document, you may use this property. |
-| icon | `string` | false | Font Awesome icon name for the operation button. Each method has a default icon if not specified:<br>- post: "plus"<br>- put: "pencil-square-o"<br>- delete: "times" |
 | requestHeaders | `object` | false | Same as above, but for specific method. |
 | queryParams | `array` | false | An array of query parameters fields that will be added to the request. <br /><br />If your url includes the name of the parameter, it will be used as part of the path rather than as a query parameter. For example if your url is ``/api/contact/234/address`` you might make a parameter called ``contactId`` then set the url as follows: ``/api/contact/:contactId/address``. <br /><br />Each query param item is an object. See [input fields](#input-fields) |
 | fields | `array` | false | A list of [Input fields](#input-fields) that will be used as the body of the request. <br /><br /> For the `getAll` request, the fields will be a list to [display fields](#display-fields) and will be used to render the main view. |
@@ -321,7 +291,6 @@ Example:
 ```
 {
   "url": "/character",
-  "icon": "plus",
   "fields": [
     {
       "name": "name",
@@ -378,7 +347,6 @@ Example:
     "url": "/character/:id",
     "actualMethod": "post",
     "includeOriginalFields": false,
-    "icon": "pencil",
     "fields": [
       {
         "name": "location",
@@ -431,8 +399,7 @@ Example:
 ```
 {
   "delete": {
-    "url": "/character/:id",
-    "icon": "trash"
+    "url": "/character/:id"
   }
 }
 ```
@@ -561,7 +528,6 @@ Here's a list of variable names you may change:
 |--------------|-----|----------------------------------------------------------------|
 | appText | `string` | Root text color. |
 | appBackground | `string` | App background color. |
-| logoHeaderBackground | `string` | Logo header background color. |
 | navBackground | `string` | Navigation menu background color. |
 | navText | `string` | Navigation menu text color. |
 | navItemText | `string` | Navigation item text color. |
@@ -910,14 +876,6 @@ The field name will be `url`, the type will be `text`, and the data path will be
 
 
 <br />
-
-### Logo Header
-
-To add a logo at the top of the page:
-1. Add your logo image file named `logo.png` to this directory (`src/assets/images/`).
-2. The logo will automatically appear in the header when the file exists.
-3. The header will remain hidden if no logo file is present.
-
 
 ### Internationalization (i18n)
 

--- a/README.md
+++ b/README.md
@@ -897,11 +897,11 @@ For example, for the "Characters" page:
 }
 ```
 
-##### Field labels
+##### Field labels and help texts
 
-Define the field labels in the language files under the namespace of the page.
+Define the field labels and optional help texts in the language files under the namespace of the page.
 Use the `id` of the page as defined in the configuration file.
-Then define the translations of the field labels under the `fields` property with the field `name` as the key.
+Then define the translations of the field labels and help texts under the `fields` property with the field `name` as the key.
 For example, for the "Characters" page:
 
 ```json
@@ -909,8 +909,14 @@ For example, for the "Characters" page:
   "pages": {
     "characters": {
       "fields": {
-        "name": "Nom",
-        "age": "Âge",
+        "name": {
+          "label": "Nom",
+          "helpText": "Entrez le nom complet du personnage"
+        },
+        "age": {
+          "label": "Âge",
+          "helpText": "Âge du personnage en années"
+        }
       }
     }
   }

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -156,21 +156,28 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
               key={`card_${cardIdx}_${fieldIdx}`}
             >
               {field.type !== "image" && (
-                <label
-                  onClick={() => {
-                    if (field.queryShortcut) {
-                      callbacks.setQueryParam(
-                        field.queryShortcut.name,
-                        field.queryShortcut.value ||
-                          `${field.dataPath ? field.dataPath + "." : ""}${
-                            field.name
-                          }`
-                      );
-                    }
-                  }}
-                >
-                  {field.label || translatePage(`fields.${field.name}.label`) || field.name}:{" "}
-                </label>
+                <div className="card-row-header">
+                  <label
+                    onClick={() => {
+                      if (field.queryShortcut) {
+                        callbacks.setQueryParam(
+                          field.queryShortcut.name,
+                          field.queryShortcut.value ||
+                            `${field.dataPath ? field.dataPath + "." : ""}${
+                              field.name
+                            }`
+                        );
+                      }
+                    }}
+                  >
+                    {field.label || translatePage(`fields.${field.name}.label`) || field.name}:{" "}
+                  </label>
+                  {translatePage(`fields.${field.name}.helpText`, { returnNull: true }) && (
+                    <div className="help-text">
+                      {translatePage(`fields.${field.name}.helpText`)}
+                    </div>
+                  )}
+                </div>
               )}
               {renderRow(field, item, value)}
             </div>

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -29,8 +29,12 @@
   .card-row {
     margin: 0 20px 10px;
     display: flex;
-    align-items: center;
-    justify-content: flex-start;
+    
+    .card-row-header {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 4px;
+    }
 
     label {
       font-size: 14px;
@@ -39,7 +43,13 @@
       flex-shrink: 0;
     }
 
-    > *:not(label) {
+    .help-text {
+      color: #666;
+      font-style: italic;
+      font-size: 12px;
+    }
+
+    > *:not(.card-row-header) {
       flex: 1;
       word-break: break-word;
     }

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -71,14 +71,10 @@ export const FormRow = withAppContext(
     };
 
     const getHelpText = () => {
-      const pageId = activePage?.id;
-      if (pageId && field.originalName) {
-        const helpText = translatePage(`fields.${field.originalName}.helpText`, { returnNull: true });
-        if (helpText) {
-          return helpText;
-        }
+      if (!activePage?.id || !field.originalName) {
+        return null;
       }
-      return null;
+      return translatePage(`fields.${field.originalName}.helpText`, { returnNull: true });
     };
 
     async function loadOptionSourceFromRemote(

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -70,6 +70,17 @@ export const FormRow = withAppContext(
       return field.originalName;
     };
 
+    const getHelpText = () => {
+      const pageId = activePage?.id;
+      if (pageId && field.originalName) {
+        const helpText = translatePage(`fields.${field.originalName}.helpText`, { returnNull: true });
+        if (helpText) {
+          return helpText;
+        }
+      }
+      return null;
+    };
+
     async function loadOptionSourceFromRemote(
       fieldName: string,
       optionSource: IConfigOptionSource,
@@ -503,18 +514,25 @@ export const FormRow = withAppContext(
             {field.required ? " *" : ""}
           </label>
         )}
-        {renderFieldInput(field, onChange)}
-        {showReset &&
-          !field.readonly &&
-          field.value &&
-          field.value.length > 0 && (
-            <i
-              title={clearLabel}
-              onClick={() => onChange(field.name, "", true)}
-              aria-label={translatePage('aria.clear')}
-              className="clear-input fa fa-times"
-            ></i>
+        <div className="field-container">
+          <div className="field-input">
+            {renderFieldInput(field, onChange)}
+            {showReset &&
+              !field.readonly &&
+              field.value &&
+              field.value.length > 0 && (
+                <i
+                  title={clearLabel}
+                  onClick={() => onChange(field.name, "", true)}
+                  aria-label={translatePage('aria.clear')}
+                  className="clear-input fa fa-times"
+                ></i>
+              )}
+          </div>
+          {getHelpText() && (
+            <div className="help-text">{getHelpText()}</div>
           )}
+        </div>
       </div>
     );
   }

--- a/src/components/formRow/formRow.scss
+++ b/src/components/formRow/formRow.scss
@@ -1,7 +1,7 @@
 .form-row {
   display: flex;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   margin-bottom: 15px;
   position: relative;
 
@@ -86,21 +86,15 @@
     }
   }
   
-  .field-container {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-
-    input[type=text], 
-    select, 
-    textarea, 
-    input[type=url], 
-    input[type=number], 
-    input[type=date], 
-    input[type=email], 
-    input[type=password], 
-    input[type=date] {
+  > input[type=text], 
+  > select, 
+  > textarea, 
+  > input[type=url], 
+  > input[type=number], 
+  > input[type=date], 
+  > input[type=email], 
+  > input[type=password], 
+  > input[type=date] {
     width: 100%;
     padding: 9px;
     border: 1px solid rgba(0,0,0,0.1);
@@ -126,52 +120,33 @@
       color: #c5c9d2;
     }
 
-      &::selection {
-        background-color: #AAB0BE;
-        color: #fff;
-      }
-      
-      &:focus {
-        color: #1d1e21;
-        box-shadow: 0 0 3px rgba(0,0,0,0.35);
-        outline: none;
-      }
+    &::selection {
+      background-color: #AAB0BE;
+      color: #fff;
     }
+    
+    &:focus {
+      color: #1d1e21;
+      box-shadow: 0 0 3px rgba(0,0,0,0.35);
+      outline: none;
+    }
+  }
 
-    textarea {
-      height: 120px;
-      min-height: 120px;
-    }
+  textarea {
+    height: 120px;
+    min-height: 120px;
+  }
 
-    input[type=text] {
-      padding-right: 25px;
-    }
+  input[type=text] {
+    padding-right: 25px;
+  }
 
-    input[type=date] {
-      font-family: 'Open Sans', sans-serif;
-    }
+  input[type=date] {
+    font-family: 'Open Sans', sans-serif;
+  }
 
-    input[type=checkbox] {
-      flex: 1;
-    }
-
-    .clear-input {
-      position: absolute;
-      right: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-
-    .help-text {
-      color: #666;
-      font-style: italic;
-      font-size: 12px;
-      margin-top: 2px;
-    }
-
-    .field-input {
-      position: relative;
-    }
+  input[type=checkbox] {
+    flex: 1;
   }
 
   .jsoneditor {

--- a/src/components/formRow/formRow.scss
+++ b/src/components/formRow/formRow.scss
@@ -1,13 +1,25 @@
 .form-row {
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 15px;
   position: relative;
 
   @media screen and (max-width: 620px) {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .help-text {
+    color: #666;
+    font-style: italic;
+    font-size: 12px;
+    margin-top: 4px;
+    width: 100%;
+    
+    @media screen and (max-width: 620px) {
+      margin-left: 0;
+    }
   }
 
   > label {
@@ -31,8 +43,15 @@
     }
   }
 
-  > *:not(label) {
+  .field-container {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    > *:not(.help-text) {
+      width: 100%;
+    }
   }
 
   .array-form {
@@ -67,15 +86,21 @@
     }
   }
   
-  > input[type=text], 
-  > select, 
-  > textarea, 
-  > input[type=url], 
-  > input[type=number], 
-  > input[type=date], 
-  > input[type=email], 
-  > input[type=password], 
-  > input[type=date] {
+  .field-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    input[type=text], 
+    select, 
+    textarea, 
+    input[type=url], 
+    input[type=number], 
+    input[type=date], 
+    input[type=email], 
+    input[type=password], 
+    input[type=date] {
     width: 100%;
     padding: 9px;
     border: 1px solid rgba(0,0,0,0.1);
@@ -101,33 +126,52 @@
       color: #c5c9d2;
     }
 
-    &::selection {
-      background-color: #AAB0BE;
-      color: #fff;
+      &::selection {
+        background-color: #AAB0BE;
+        color: #fff;
+      }
+      
+      &:focus {
+        color: #1d1e21;
+        box-shadow: 0 0 3px rgba(0,0,0,0.35);
+        outline: none;
+      }
     }
-    
-    &:focus {
-      color: #1d1e21;
-      box-shadow: 0 0 3px rgba(0,0,0,0.35);
-      outline: none;
+
+    textarea {
+      height: 120px;
+      min-height: 120px;
     }
-  }
 
-  textarea {
-    height: 120px;
-    min-height: 120px;
-  }
+    input[type=text] {
+      padding-right: 25px;
+    }
 
-  input[type=text] {
-    padding-right: 25px;
-  }
+    input[type=date] {
+      font-family: 'Open Sans', sans-serif;
+    }
 
-  input[type=date] {
-    font-family: 'Open Sans', sans-serif;
-  }
+    input[type=checkbox] {
+      flex: 1;
+    }
 
-  input[type=checkbox] {
-    flex: 1;
+    .clear-input {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    .help-text {
+      color: #666;
+      font-style: italic;
+      font-size: 12px;
+      margin-top: 2px;
+    }
+
+    .field-input {
+      position: relative;
+    }
   }
 
   .jsoneditor {

--- a/src/components/formRow/formRow.scss
+++ b/src/components/formRow/formRow.scss
@@ -1,7 +1,7 @@
 .form-row {
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   margin-bottom: 15px;
   position: relative;
 
@@ -86,15 +86,21 @@
     }
   }
   
-  > input[type=text], 
-  > select, 
-  > textarea, 
-  > input[type=url], 
-  > input[type=number], 
-  > input[type=date], 
-  > input[type=email], 
-  > input[type=password], 
-  > input[type=date] {
+  .field-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    input[type=text], 
+    select, 
+    textarea, 
+    input[type=url], 
+    input[type=number], 
+    input[type=date], 
+    input[type=email], 
+    input[type=password], 
+    input[type=date] {
     width: 100%;
     padding: 9px;
     border: 1px solid rgba(0,0,0,0.1);
@@ -120,33 +126,52 @@
       color: #c5c9d2;
     }
 
-    &::selection {
-      background-color: #AAB0BE;
-      color: #fff;
+      &::selection {
+        background-color: #AAB0BE;
+        color: #fff;
+      }
+      
+      &:focus {
+        color: #1d1e21;
+        box-shadow: 0 0 3px rgba(0,0,0,0.35);
+        outline: none;
+      }
     }
-    
-    &:focus {
-      color: #1d1e21;
-      box-shadow: 0 0 3px rgba(0,0,0,0.35);
-      outline: none;
+
+    textarea {
+      height: 120px;
+      min-height: 120px;
     }
-  }
 
-  textarea {
-    height: 120px;
-    min-height: 120px;
-  }
+    input[type=text] {
+      padding-right: 25px;
+    }
 
-  input[type=text] {
-    padding-right: 25px;
-  }
+    input[type=date] {
+      font-family: 'Open Sans', sans-serif;
+    }
 
-  input[type=date] {
-    font-family: 'Open Sans', sans-serif;
-  }
+    input[type=checkbox] {
+      flex: 1;
+    }
 
-  input[type=checkbox] {
-    flex: 1;
+    .clear-input {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    .help-text {
+      color: #666;
+      font-style: italic;
+      font-size: 12px;
+      margin-top: 2px;
+    }
+
+    .field-input {
+      position: relative;
+    }
   }
 
   .jsoneditor {

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -176,14 +176,28 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
                       callbacks.setQueryParam(
                         field.queryShortcut.name,
                         field.queryShortcut.value ||
-                          `${field.dataPath ? field.dataPath + "." : ""}${
-                            field.name
-                          }`
+                        `${field.dataPath ? field.dataPath + "." : ""}${field.name}`
                       );
                     }
                   }}
                 >
-                  {field.label || translatePage(`fields.${field.name}.label`) || field.name}
+                  <div className="th-content">
+                    <span>{field.label || translatePage(`fields.${field.name}.label`) || field.name}</span>
+                    {translatePage(`fields.${field.name}.helpText`, { returnNull: true }) && (
+
+                      <i
+                        className="fa fa-question-circle help-icon"
+                        aria-hidden="true"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        <span className="help-text">
+                          {translatePage(`fields.${field.name}.helpText`)}
+                        </span>
+                      </i>
+                    )}
+                  </div>
                 </th>
               );
             })}

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -3,7 +3,7 @@
 .table-wrapper {
   position: relative;
   max-width: 100%;
-  overflow-x: auto;
+  overflow: visible;
 }
 
 .pure-table {
@@ -21,7 +21,6 @@
 
   tbody tr {
     transition: background 0.1s ease;
-    
     &:hover {
       background: #f7f7f7;
     }
@@ -40,10 +39,75 @@
     padding-top: 21px;
     padding-bottom: 21px;
     font-weight: 700;
-    position: sticky;
-    top: 0;
     background: #fff;
     box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+
+    .th-content {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      .help-icon {
+        position: relative;
+        display: inline-block;
+        color: #999;
+
+        .help-text {
+          visibility: hidden;
+          opacity: 0;
+          position: absolute;
+          min-width: 120px;
+          max-width: 250px;
+          left: 50%;
+          margin-left: -60px;
+          bottom: 100%;  /* Use half of the width (120/2 = 60), to center the tooltip */
+          z-index: 1000;
+
+          font-family: 'Open Sans', sans-serif;
+          color: black;
+          background-color: #e6e6e6;
+          padding: 8px 12px;
+          border-radius: 4px;
+          margin-bottom: 10px;
+          transition: opacity 0.5s ease, visibility 0.5s ease;
+
+          text-align: left;
+          white-space: normal;
+          line-height: 1.4;
+          font-size: 14px;
+          text-transform: none;
+
+          // After element vor triangle
+          &::after {
+            content: '';
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            margin-left: -5px;
+            border-width: 5px;
+            border-style: solid;
+            border-color: #e6e6e6 transparent transparent transparent;
+          }
+        }
+      }
+
+      .help-icon {
+        &:hover {
+          .help-text {
+            visibility: visible;
+            opacity: 1;
+          }
+
+          opacity: 1;
+        }
+
+        .help-text {
+          transition: opacity 0.15s ease-in-out;
+        }
+      }
+
+
+    }
   }
 
   td {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,7 +105,13 @@
         "submitAdd": "<submit>"
       },
       "description": "<description>",
-      "title": "<title>"
+      "title": "<title>",
+      "fields": {
+        "<field-name>": {
+          "label": "<label>",
+          "helpText": "<helpText>"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This adds the option to define a help text for individual fields.
The help text can be configured via i18n language files and is displayed differently depending on the layout - below the field names in card layout and as hoverable icons in table layout.