### PR TITLE
Add option to show logo header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ The idea behind it is simple. Given the fact that each entity in your API has a 
 
 <br />
 
+## Table of Contents
+
+- [What's New in V2?](#whats-new-in-v2)
+- [Getting started](#getting-started)
+- [Configuration](#configuration)
+  - [Authorization](#auth-config)
+  - [Pages](#pages)
+  - [Methods](#methods)
+    - [`getAll` - additional properties](#getall---additional-properties)
+    - [`getSingle`](#getsingle)
+    - [`post`](#post)
+    - [`put` - additional properties](#put---additional-properties)
+    - [`delete`](#delete)
+  - [Pagination](#pagination)
+  - [Custom Actions](#custom-actions)
+  - [Custom Styles](#custom-styles)
+  - [Custom Labels](#custom-labels)
+  - [Display fields](#display-fields)
+  - [Input fields](#input-fields)
+  - [Logo Header](#logo-header)
+  - [Internationalization (i18n)](#internationalization-i18n)
+- [Development](#development)
+  - [Local Development](#local-development)
+  - [Consume from CDN](#consume-from-cdn)
+  - [Deploy](#deploy)
+- [Contributing](#contributing)
+
 ## What's New in V2?
 
 While RESTool originally was developed with Angular, we decided to rewrite it from scratch and move to **React**. The main reason we moved to React is the **community**. Since React is so popular we believe that choosing React over Angular will get a much wider **community support**.
@@ -528,6 +555,7 @@ Here's a list of variable names you may change:
 |--------------|-----|----------------------------------------------------------------|
 | appText | `string` | Root text color. |
 | appBackground | `string` | App background color. |
+| logoHeaderBackground | `string` | Logo header background color. |
 | navBackground | `string` | Navigation menu background color. |
 | navText | `string` | Navigation menu text color. |
 | navItemText | `string` | Navigation item text color. |
@@ -867,6 +895,14 @@ The field name will be `url`, the type will be `text`, and the data path will be
 
 
 <br />
+
+### Logo Header
+
+To add a logo at the top of the page:
+1. Add your logo image file named `logo.png` to this directory (`src/assets/images/`).
+2. The logo will automatically appear in the header when the file exists.
+3. The header will remain hidden if no logo file is present.
+
 
 ### Internationalization (i18n)
 

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -86,6 +86,10 @@
               "type": "string",
               "description": "App background color."
             },
+            "logoHeaderBackground": {
+              "type": "string",
+              "description": "Logo header bar background color."
+            },
             "navBackground": {
               "type": "string",
               "description": "Navigation menu background color."

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -34,6 +34,7 @@ export interface ICustomStyles {
   vars?: {
     appText?: string;
     appBackground?: string;
+    logoHeaderBackground?: string;
     navBackground?: string;
     navText?: string;
     navItemText?: string;

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -2,57 +2,54 @@
 @import '../common/styles/functions';
 
 .restool-app {
-  display: flex;
-  justify-content: flex-start;
-  align-items: stretch;
-  min-height: 100vh;
-
   --nav-width: 260px;
 
-  @media screen and (max-width: 800px) {
-    flex-direction: column;
-  }
-
-  aside {
-    width: var(--nav-width);
-    background: v(navBackground, #3C3E6F);
-    color: v(navText, #fff);
-    box-shadow: inset -2px 0px 3px rgba(0, 0, 0, 0.3);
-    z-index: 10;
-    position: sticky;
-    top: 0;
-    height: 100vh;
+  .app-content {
+    display: flex;
+    justify-content: flex-start;
+    align-items: stretch;
 
     @media screen and (max-width: 800px) {
-      height: auto;
-      width: 100%;
+      flex-direction: column;
     }
 
-    h1 {
-      padding: 20px;
-      margin: 0;
-      font-size: 20px;
-      font-weight: 300;
-      margin: 0;
-      height: 63px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      cursor: default;
+    aside {
+      width: var(--nav-width);
+      background: v(navBackground, #3C3E6F);
+      color: v(navText, #fff);
+      box-shadow: inset -2px 0px 3px rgba(0, 0, 0, 0.3);
+      z-index: 10;
 
       @media screen and (max-width: 800px) {
-        text-align: center;
+        height: auto;
+        width: 100%;
+      }
+
+      h1 {
+        padding: 20px;
+        margin: 0;
+        font-size: 20px;
+        font-weight: 300;
+        height: 63px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        cursor: default;
+
+        @media screen and (max-width: 800px) {
+          text-align: center;
+        }
       }
     }
-  }
-  
-  main {
-    position: relative;
-    flex: 1;
-    max-width: calc(100vw - 30px - var(--nav-width));
     
-    @media screen and (max-width: 800px) {
-      max-width: 100%;
+    main {
+      position: relative;
+      flex: 1;
+      max-width: calc(100vw - 30px - var(--nav-width));
+      
+      @media screen and (max-width: 800px) {
+        max-width: 100%;
+      }
     }
   }
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -16,6 +16,7 @@ import { LoginPage } from './auth/loginPage/loginPage.comp';
 import { ChangePasswordPage } from './auth/changePasswortPage/changePasswortPage.comp';
 import AuthService from '../services/auth.service';
 import { usePageTranslation } from '../hooks/usePageTranslation';
+import { Header } from './header/header.comp';
 
 const httpService = new HttpService();
 const authService = new AuthService();
@@ -141,16 +142,19 @@ function App() {
               <CustomStyles styles={config.customStyles} />
             }
             <Router>
-              <aside>
-                <h1 title={appName} onClick={() => scrollToTop()}>{appName}</h1>
-                <Navigation />
-              </aside>
-              <Switch>
-                <Route exact path='/login' component={LoginPage} />
-                <Route exact path='/change-password' component={ChangePasswordPage} />
-                <Route exact path="/:page" component={Page} />
-                <Redirect path="/" to={`/${config?.pages?.[0]?.id || '1'}`} />
-              </Switch>
+              <Header />
+              <div className="app-content">
+                <aside>
+                  <h1 title={appName} onClick={() => scrollToTop()}>{appName}</h1>
+                  <Navigation />
+                </aside>
+                  <Switch>
+                    <Route exact path='/login' component={LoginPage} />
+                    <Route exact path='/change-password' component={ChangePasswordPage} />
+                    <Route exact path="/:page" component={Page} />
+                    <Redirect path="/" to={`/${config?.pages?.[0]?.id || '1'}`} />
+                  </Switch>
+              </div>
               <ToastContainer position={toast.POSITION.TOP_CENTER} autoClose={4000} draggable={false} />
             </Router>
           </AppContext.Provider>

--- a/src/components/header/header.comp.tsx
+++ b/src/components/header/header.comp.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useContext } from 'react';
+import { AppContext } from '../app.context';
+import './header.scss';
+
+// Logo will be imported when it exists
+let logoImage: string | undefined;
+try {
+  // Dynamic import for logo - will throw if file doesn't exist
+  logoImage = require('../../assets/images/logo.png');
+} catch (e) {
+  logoImage = undefined;
+}
+
+export const Header: React.FC = () => {
+  const { config } = useContext(AppContext);
+
+  // Only show header if logo exists
+  if (!logoImage) {
+    return null;
+  }
+
+  return (
+    <header className="restool-header">
+      <div className="header-content">
+        <div className="logo-container">
+          <img src={logoImage} alt={config?.name} className="logo" />
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,3 +1,5 @@
+@import "../../common/styles/functions";
+
 .restool-header {
     width: 100%;
     height: 60px;

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -1,0 +1,31 @@
+.restool-header {
+    width: 100%;
+    height: 60px;
+    background: v(logoHeaderBackground, white);
+
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+
+    .header-content {
+        padding: 0 20px;
+        height: 100%;
+        display: flex;
+        align-items: center;
+    }
+
+    .logo-container {
+
+        height: 40px;
+
+        .logo {
+            height: 100%;
+            width: auto;
+            object-fit: contain;
+        }
+
+    }
+
+
+}


### PR DESCRIPTION
Adds support for a logo.png in the header (header is hidden if no logo is provided). 
To add the logo, simply a `logo.png` file needs to be present in /src/assets/images.
Also improves README readability with a table of contents.

Let me know what you think 😊 