### PR TITLE
Add optional icons to page navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Each **page** is an object and represents a resource in your API. It should have
 | name | `string` | true | The name of the page. This will be presented in the menu. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | id | `string` | true | A unique identifier for the page. RESTool will use it to navigate between pages. |
 | description | `string` | false | A short description about the page and its usage. For translation support, it's recommended to leave this empty and define it in under the page's and field's namespace instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
+| icon | `string` | false | Font Awesome icon name (without the 'fa-' prefix) to display next to the page name in navigation. For example: 'cog', 'user', 'key', etc. |
 | requestHeaders | `object` | false | A list of key-value headers you wish to add to every request we're making. <br /><br /> For example: <br />``{ Authentication: 'SECRET_KEY', 'X-USER-ID': 'USER_ID' }``. |
 | methods | `object` | true | A list of all methods which are available in your RESTful API. |
 | customActions | `object[]` | false | A list of extra (non RESTful) endpoints available in your RESTful API. Specifically `customActions` is a list of PUT or POST method objects. <br /><br />Read more about custom actions [here](#custom-actions). |

--- a/public/config-sample.js
+++ b/public/config-sample.js
@@ -8,6 +8,7 @@ export default {
       "name": "Cast & Characters",
       "id": "characters",
       "description": "Manage GOT characters location and budget.",
+      "icon": "users",
       "methods": {
         "getAll": {
           "label": "Get All",
@@ -165,6 +166,7 @@ export default {
       "name": "Employees",
       "id": "employees",
       "description": "Manage GOT employees, people and employees.",
+      "icon": "suitcase",
       "methods": {
         "getAll": {
           "label": "Get All",
@@ -260,6 +262,7 @@ export default {
       "name": "Deads",
       "id": "deads",
       "description": "Manage GOT deads 😵",
+      "icon": "frown-o",
       "methods": {
         "getAll": {
           "label": "Get All",

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -181,6 +181,10 @@
         "customLink": {
           "type": "string",
           "description": "External link to page"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Font Awesome icon name without the 'fa-' prefix to display next to the page name in navigation. For example: 'cog', 'user', 'key', etc."
         }
       },
       "required": [

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -103,6 +103,7 @@ export interface IConfigPage {
   name: string;
   id: string;
   description: string;
+  icon?: string;
   requestHeaders?: any;
   methods?: IConfigMethods;
   customActions?: IConfigCustomAction[];

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -43,10 +43,17 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
           {
             (config?.pages || []).map((page, idx) => {
               const pageName = translate(`pages.${page.id}.title`) || page.id;
+              const icon = page.icon ? <i className={`fa fa-${page.icon}`} aria-hidden="true"></i> : null;
               return page?.customLink ?
-                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
+                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>
+                  {icon}
+                  <span className="nav-item-text">{pageName}</span>
+                </a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
-                  onClick={() => setIsOpened(false)}>{pageName}</NavLink>
+                  onClick={() => setIsOpened(false)}>
+                  {icon}
+                  <span className="nav-item-text">{pageName}</span>
+                </NavLink>
             })
           }
         </div>

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -60,6 +60,16 @@
       margin: 0;
       font-size: 14px;
       line-height: 1.3em;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      i {
+        font-size: 14px;
+        width: 14px;
+        text-align: center;
+      }
+
       cursor: pointer;
       transition: 0.2s background-color ease 0s;
 


### PR DESCRIPTION
Adds the option to define an icon in the page config, which will be shown in the navigation bar.


![grafik](https://github.com/user-attachments/assets/17654596-ce09-4fd6-91a4-46322e87757f)

If no icon is not defined, navigation remains the same as before:

![grafik](https://github.com/user-attachments/assets/503597ee-bc6d-45ed-bfcd-639eeea279e0)
