### PR TITLE
Positioning of auth-related navbar items + Introducing Navbar section labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The `auth` property allows you to configure authentication endpoints. It has the
 | logoutEndpoint | `string` | true | The endpoint to send the logout request to. | Request: `POST` <br> Response: `200 OK` |
 | userEndpoint | `string` | true | The endpoint to get the user data from. It should return a JSON object with the property `username`. | Request: `GET` <br> Response: `{ username: string }` |
 | changePasswordEndpoint | `string` | true | The endpoint to send password change requests to. | Request: `PUT { oldPassword: string, newPassword: string }` <br> Response: `200 OK` |
+| icons | `object` | false | Optional configuration for UI icons. Contains `changePassword` and `logout` properties that accept Font Awesome icon names. When not defined for an action, no icon will be shown. | Example: `{ changePassword: "retweet", logout: "sign-out" }` |
 
 Example auth configuration:
 ```json

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -14,6 +14,10 @@ export interface IAuthConfig {
   logoutEndpoint: string;
   userEndpoint: string;
   changePasswordEndpoint: string;
+  icons?: {
+    changePassword?: string;
+    logout?: string;
+  };
 }
 
 export interface IConfig {

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -14,6 +14,8 @@
   }
 
   aside {
+    display: flex;
+    flex-direction: column;
     width: var(--nav-width);
     background: v(navBackground, #3C3E6F);
     color: v(navText, #fff);

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -39,26 +39,43 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
       </Button>
 
       <div className={`app-nav-wrapper ${isOpened ? 'opened' : ''}`}>
-        <div className="app-nav-links">
-          {
-            (config?.pages || []).map((page, idx) => {
-              const pageName = translate(`pages.${page.id}.title`) || page.id;
-              return page?.customLink ?
-                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
-                <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
-                  onClick={() => setIsOpened(false)}>{pageName}</NavLink>
-            })
-          }
+        <div className="app-nav-section">
+          {!!translate('navigation.pages') && (
+            <div className="app-nav-section-header">
+              {translate('navigation.pages')}
+            </div>
+          )}
+          <div className="app-nav-links">
+            {
+              (config?.pages || []).map((page, idx) => {
+                const pageName = translate(`pages.${page.id}.title`) || page.id;
+                return page?.customLink ?
+                  <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
+                  <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
+                    onClick={() => setIsOpened(false)}>{pageName}</NavLink>
+              })
+            }
+          </div>
         </div>
         {!!loggedInUsername && (
-          <div className="app-nav-logout">
-            <NavLink to="/change-password" className="change-password-link">
-              {translate('auth.changePassword')}
-            </NavLink>
-            <NavLink to="/login" onClick={logout} className="logout-link">
-              {translate('auth.logout')} ({loggedInUsername})
-            </NavLink>
+          <div className="app-nav-section">
+            {!!translate('navigation.userManagement') && (
+              <div className="app-nav-section-header">
+                {translate('navigation.userManagement')}
+              </div>
+            )}
+            <div className="app-nav-logout">
+              <NavLink to="/change-password" className="change-password-link">
+                {translate('auth.changePassword')}
+              </NavLink>
+              <NavLink to="/login" onClick={logout} className="logout-link">
+                {translate('auth.logout')} ({loggedInUsername})
+              </NavLink>
+            </div>
           </div>
+        )}
+        {!loggedInUsername && (
+          <div className="app-nav-section" />
         )}
       </div>
     </nav>

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -66,9 +66,15 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
             )}
             <div className="app-nav-logout">
               <NavLink to="/change-password" className="change-password-link">
+                {config?.auth?.icons?.changePassword && (
+                  <i className={`fa fa-${config.auth.icons.changePassword}`} aria-hidden="true"></i>
+                )}{' '}
                 {translate('auth.changePassword')}
               </NavLink>
               <NavLink to="/login" onClick={logout} className="logout-link">
+                {config?.auth?.icons?.logout && (
+                  <i className={`fa fa-${config.auth.icons.logout}`} aria-hidden="true"></i>
+                )}{' '}
                 {translate('auth.logout')} ({loggedInUsername})
               </NavLink>
             </div>

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -3,6 +3,7 @@
 .app-nav {
   text-align: left;
   overflow: auto;
+  height: 100%;
 
   .app-nav-opener {
     position: absolute;
@@ -26,6 +27,11 @@
   }
 
   .app-nav-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+
     @media screen and (max-width: 800px) { 
       display: none;
       width: 100%;
@@ -35,14 +41,29 @@
       top: 0;
       overflow: auto;
       background: #3C3E6F;
-      justify-content: center;
-      align-items: center;
       text-align: center;
       padding: 40px;
     }
 
     &.opened {
       display: flex;
+    }
+
+    .app-nav-section {
+      width: 100%;
+
+      &:last-child {
+        margin-top: auto;
+      }
+    }
+
+    .app-nav-section-header {
+      color: v(navItemText, #fff);
+      font-size: 12px;
+      font-weight: bold;
+      padding: 10px 20px 10px 20px;
+      opacity: 0.7;
+      letter-spacing: 1px;
     }
 
     .app-nav-links {
@@ -84,7 +105,7 @@
     }
 
     .app-nav-logout {
-      padding-top: 2rem;
+      padding-bottom: 1rem;
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,6 +99,10 @@
       "editItem": "Item updated successfully"
     }
   },
+  "navigation": {
+    "pages": "PAGES",
+    "userManagement": "USER MANAGEMENT"
+  },
   "pages": {
     "<example-page-id>": {
       "buttons": {


### PR DESCRIPTION
This pull request improves the styling of the navbar by moving the auth-related items (Change Password + Logout) to the bottom of the navbar.
It also adds section labels to the "page" section at the top of the navbar and the "auth" section at the bottom.  These can be translated using i18nfile or removed using i18n to not display them at all.

![grafik](https://github.com/user-attachments/assets/a107c79c-4175-4bc2-a183-273923efc1df)
