### PR TITLE
Custom Icons for post/put/delete action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Each method has the following common properties (which could be extended specifi
 |----------------|--------------|-----|----------------------------------------------------------------|
 | url | `string` | true | The url for making the request. The url could be either relative or absolute. If a ``baseUrl`` is defined then you should only provide a relative path. For example: ``/users/:id``. <br /><br />The url could contain parameters that will be extracted if needed. For example: ``https://website.com/users/:id`` - note that the parameter name in the url should match the one you're returning in your API. |
 | actualMethod | `string` ("get", "put", "post", "delete", "patch") | false | Since not everyone implements the RESTful standard, if you need to make a 'post' request in order to update an exiting document, you may use this property. |
+| icon | `string` | false | Font Awesome icon name for the operation button. Each method has a default icon if not specified:<br>- post: "plus"<br>- put: "pencil-square-o"<br>- delete: "times" |
 | requestHeaders | `object` | false | Same as above, but for specific method. |
 | queryParams | `array` | false | An array of query parameters fields that will be added to the request. <br /><br />If your url includes the name of the parameter, it will be used as part of the path rather than as a query parameter. For example if your url is ``/api/contact/234/address`` you might make a parameter called ``contactId`` then set the url as follows: ``/api/contact/:contactId/address``. <br /><br />Each query param item is an object. See [input fields](#input-fields) |
 | fields | `array` | false | A list of [Input fields](#input-fields) that will be used as the body of the request. <br /><br /> For the `getAll` request, the fields will be a list to [display fields](#display-fields) and will be used to render the main view. |
@@ -291,6 +292,7 @@ Example:
 ```
 {
   "url": "/character",
+  "icon": "plus",
   "fields": [
     {
       "name": "name",
@@ -347,6 +349,7 @@ Example:
     "url": "/character/:id",
     "actualMethod": "post",
     "includeOriginalFields": false,
+    "icon": "pencil",
     "fields": [
       {
         "name": "location",
@@ -399,7 +402,8 @@ Example:
 ```
 {
   "delete": {
-    "url": "/character/:id"
+    "url": "/character/:id",
+    "icon": "trash"
   }
 }
 ```

--- a/public/config-sample.js
+++ b/public/config-sample.js
@@ -64,6 +64,7 @@ export default {
         },
         "put": {
           "url": "/character/:id",
+          "icon": "pencil",
           "fields": [
             {
               "name": "isAlive",
@@ -86,6 +87,7 @@ export default {
         },
         "post": {
           "url": "/character",
+          "icon": "plus-circle",
           "fields": [
             {
               "name": "thumbnail",
@@ -116,7 +118,8 @@ export default {
           ]
         },
         "delete": {
-          "url": "/character/:id"
+          "url": "/character/:id",
+          "icon": "trash"
         }
       },
       "customActions": [{

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -321,6 +321,10 @@
         },
         {
           "properties": {
+            "icon": {
+              "type": "string",
+              "description": "Font Awesome icon name for the add/create button. Defaults to 'plus' if not specified."
+            },
             "fields": {
               "type": "array",
               "items": {
@@ -342,6 +346,10 @@
         },
         {
           "properties": {
+            "icon": {
+              "type": "string",
+              "description": "Font Awesome icon name for the edit button. Defaults to 'pencil' if not specified."
+            },
             "fields": {
               "type": "array",
               "items": {
@@ -361,7 +369,19 @@
       "description": "The put method will be used to update an existing item in your API resource."
     },
     "delete": {
-      "$ref": "#/definitions/method",
+      "allOf": [
+        {
+          "$ref": "#/definitions/method"
+        },
+        {
+          "properties": {
+            "icon": {
+              "type": "string",
+              "description": "Font Awesome icon name for the delete button. Defaults to 'trash' if not specified."
+            }
+          }
+        }
+      ],
       "description": "The delete method will be used to delete an existing item in your API resource."
     },
     "inputField": {

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -227,15 +227,19 @@ export interface IConfigGetSingleMethod extends IConfigMethod {
 export interface IConfigPostMethod extends IConfigMethod {
   fields: IConfigInputField[];
   dataTransform?: ConfigFunction;
+  icon?: string;
 }
 
 export interface IConfigPutMethod extends IConfigMethod {
   fields: IConfigInputField[];
   dataTransform?: ConfigFunction;
   includeOriginalFields?: boolean;
+  icon?: string;
 }
 
-export interface IConfigDeleteMethod extends IConfigMethod {}
+export interface IConfigDeleteMethod extends IConfigMethod {
+  icon?: string;
+}
 
 export interface IConfigCustomAction extends IConfigMethod {
   name: string;

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -115,7 +115,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
       <div className="actions-wrapper">
         {callbacks.put && (
           <Button onClick={() => callbacks.put?.(item)} title={editLabel}>
-            <i className="fa fa-pencil-square-o" aria-hidden="true"></i>
+                <i className={`fa fa-${context.activePage?.methods?.put?.icon || 'pencil-square-o'}`} aria-hidden="true"></i>
           </Button>
         )}
         {customActions &&
@@ -134,7 +134,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
           ))}
         {callbacks.delete && (
           <Button onClick={() => callbacks.delete?.(item)} title={deleteLabel}>
-            <i className="fa fa-times" aria-hidden="true"></i>
+              <i className={`fa fa-${context.activePage?.methods?.delete?.icon || 'times'}`} aria-hidden="true"></i>
           </Button>
         )}
       </div>

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -974,7 +974,7 @@ const PageComp = ({ context }: IProps) => {
               })
             }
           >
-            {addItemLabel}
+            <i className={`fa fa-${postConfig?.icon || 'plus'}`} aria-hidden="true"></i> {addItemLabel}
           </Button>
         )}
       </header>

--- a/src/components/page/page.scss
+++ b/src/components/page/page.scss
@@ -23,10 +23,17 @@
   }
 
   .add-item {
+    display: flex;
+    align-items: center;
     font-size: 18px;
     padding: 12px 30px;
     background-color: v(addButtonBackground, #1cb841);
     color: v(addButtonText, #ffffff);
+
+    i {
+      margin-right: 8px;
+      font-size: 10px;
+    }
 
     &:hover {
       background-color: v(addButtonHoverBackground, lighten(#1cb841, 10%));

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -131,7 +131,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
           <div className="actions-wrapper">
             {callbacks.put && (
               <Button onClick={() => callbacks.put?.(item)} title={editLabel}>
-                <i className="fa fa-pencil-square-o" aria-hidden="true" />
+                <i className={`fa fa-${context.activePage?.methods?.put?.icon || 'pencil-square-o'}`} aria-hidden="true" />
               </Button>
             )}
             {customActions &&
@@ -153,7 +153,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
                 onClick={() => callbacks.delete?.(item)}
                 title={deleteLabel}
               >
-                <i className="fa fa-times" aria-hidden="true"></i>
+                <i className={`fa fa-${context.activePage?.methods?.delete?.icon || 'times'}`} aria-hidden="true"></i>
               </Button>
             )}
           </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,7 @@
     },
     "buttons": {
       "addArrayItem": "Add Item",
-      "addItem": "+ Add Item",
+      "addItem": "Add Item",
       "clearInput": "Clear",
       "closeForm": "Close",
       "deleteItem": "Delete",


### PR DESCRIPTION
Allows to define custom FA icons for the add/edit/delete action buttons, respectievly shown in 

- "Add item" button on the top of the page
- Edit + delete icons in cards layout
- Edit + delete icons in table layout

This works in the same way for the `cutomAction' already. 
Defaults to the default icons if no icons are configured in the config.