### PR TITLE
Add i18n support for field values in select dropdowns and displays

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "git.ignoreLimitWarning": true
-}

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ You can translate both field labels and field values:
         "confidentiality": {
           "label": "Confidentialité",
           "values": {  // Translates the actual field values
-            "public": "public"
+            "public": "public",
             "private": "privé"
           }
         }
@@ -933,9 +933,9 @@ You can translate both field labels and field values:
 The `values` object allows you to translate the actual values that appear in select dropdowns and displays. For example, if you have a select field with options `["public", "private"]`, you can provide translations for those values. The original values will still be sent to the backend, but users will see the translated text in the UI.
 
 This works for:
-- Select dropdown options in forms (input field type: `select`)
 - Values displayed in tables (display field type: `text`)
 - Values displayed in cards (display field type: `text`)
+- Select dropdown options in forms (input field type: `select`). For this to work, the `options` property in the configuration file should be an array of value strings, not an array of objects containing `display` and `value` properties, as described in the [Input fields](#input-fields) section.
 
 ##### Other translations
 

--- a/README.md
+++ b/README.md
@@ -897,25 +897,45 @@ For example, for the "Characters" page:
 }
 ```
 
-##### Field labels
+##### Field labels and values
 
 Define the field labels in the language files under the namespace of the page.
 Use the `id` of the page as defined in the configuration file.
-Then define the translations of the field labels under the `fields` property with the field `name` as the key.
-For example, for the "Characters" page:
+Then define the translations under the `fields` property with the field `name` as the key.
+
+You can translate both field labels and field values:
 
 ```json
 {
   "pages": {
     "characters": {
       "fields": {
-        "name": "Nom",
-        "age": "Âge",
+        "name": {
+          "label": "Nom",  // Field label translation
+          "helpText": "Le nom du personnage"  // Optional help text
+        },
+        "age": {
+          "label": "Âge"
+        },
+        "confidentiality": {
+          "label": "Confidentialité",
+          "values": {  // Translates the actual field values
+            "public": "public"
+            "private": "privé"
+          }
+        }
       }
     }
   }
 }
 ```
+
+The `values` object allows you to translate the actual values that appear in select dropdowns and displays. For example, if you have a select field with options `["public", "private"]`, you can provide translations for those values. The original values will still be sent to the backend, but users will see the translated text in the UI.
+
+This works for:
+- Select dropdown options in forms (input field type: `select`)
+- Values displayed in tables (display field type: `text`)
+- Values displayed in cards (display field type: `text`)
 
 ##### Other translations
 

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -51,22 +51,25 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
       }),
   };
 
-  function renderRow(
-    origField: IConfigDisplayField,
-    origItem: any,
-    value: any
-  ) {
-    if (origField.type === "boolean") {
-      value = value ? true : false;
-    }
+    function renderRow(
+      origField: IConfigDisplayField,
+      origItem: any,
+      value: any
+    ) {
+      if (origField.type === "boolean") {
+        value = value ? true : false;
+      }
 
-    if (value && typeof value === "object") {
-      return value.toString();
-    }
+      if (value && typeof value === "object") {
+        return value.toString();
+      }
 
-    switch (origField.type) {
-      case "text":
-        return <span>{value}</span>;
+      // Try to get translated value for text fields
+      const translatedValue = origField.name ? translatePage(`fields.${origField.name}.values.${value}`, { returnNull: true }) : null;
+      
+      switch (origField.type) {
+        case "text":
+          return <span>{translatedValue || value}</span>;
       case "boolean":
         return <div className={`bool ${value ? "true" : "false"}`}></div>;
       case "image":

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -260,9 +260,10 @@ export const FormRow = withAppContext(
               {finalOptions.map((option, idx) => {
                 const key = `option_${idx}_`;
                 if (typeof option !== "object") {
+                  const translatedValue = field.originalName ? translatePage(`fields.${field.originalName}.values.${option}`, { returnNull: true }) : null;
                   return (
                     <option key={`${key}_${option}`} value={option}>
-                      {option}
+                      {translatedValue || option}
                     </option>
                   );
                 }

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -53,22 +53,25 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
       }),
   };
 
-  function renderTableCell(
-    origField: IConfigDisplayField,
-    origItem: any,
-    value: any
-  ) {
-    if (origField.type === "boolean") {
-      value = value ? true : false;
-    }
+    function renderTableCell(
+      origField: IConfigDisplayField,
+      origItem: any,
+      value: any
+    ) {
+      if (origField.type === "boolean") {
+        value = value ? true : false;
+      }
 
-    if (value && typeof value === "object") {
-      return value.toString();
-    }
+      if (value && typeof value === "object") {
+        return value.toString();
+      }
 
-    switch (origField.type) {
-      case "text":
-        return <span>{value}</span>;
+      // Try to get translated value for text fields
+      const translatedValue = origField.name ? translatePage(`fields.${origField.name}.values.${value}`, { returnNull: true }) : null;
+      
+      switch (origField.type) {
+        case "text":
+          return <span>{translatedValue || value}</span>;
       case "boolean":
         return <div className={`bool ${value ? "true" : "false"}`}></div>;
       case "image":


### PR DESCRIPTION
Adds the ability to translate select field values through the i18n system, allowing different display text in UI while maintaining original values for backend communication. Useful for showing localized options in dropdowns and translated values in tables/cards.