### PR TITLE
Add some CSS classes for easy custom overrides

### DIFF
--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -152,7 +152,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
           );
           return (
             <div
-              className={`card-row ${field.type}`}
+              className={`card-row ${field.type} ${field.name}`}
               key={`card_${cardIdx}_${fieldIdx}`}
             >
               {field.type !== "image" && (

--- a/src/components/cards/cards.comp.tsx
+++ b/src/components/cards/cards.comp.tsx
@@ -152,7 +152,7 @@ export const Cards = withAppContext(({ context, items, fields, callbacks, custom
           );
           return (
             <div
-              className={`card-row ${field.type} ${field.name}`}
+              className={`card-row card-row-${field.name} ${field.type}`}
               key={`card_${cardIdx}_${fieldIdx}`}
             >
               {field.type !== "image" && (

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -496,7 +496,7 @@ export const FormRow = withAppContext(
     }
 
     return (
-      <div className={`form-row ${direction || "row"}`}>
+      <div className={`form-row ${direction || "row"} ${field.name}`}>
         {field.type !== "hidden" && (
           <label>
             {getFieldLabel()}

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -496,7 +496,7 @@ export const FormRow = withAppContext(
     }
 
     return (
-      <div className={`form-row ${direction || "row"} ${field.name}`}>
+      <div className={`form-row ${direction || "row"} form-row-${field.name}`}>
         {field.type !== "hidden" && (
           <label>
             {getFieldLabel()}

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -44,8 +44,11 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
             (config?.pages || []).map((page, idx) => {
               const pageName = translate(`pages.${page.id}.title`) || page.id;
               return page?.customLink ?
-                <a href={page?.customLink} target="_blank" key={`page_${idx}`}>{pageName}</a> :
+                <a href={page?.customLink} target="_blank" key={`page_${idx}`} className={`app-nav-link ${page.id}`}>
+                  {pageName}
+                </a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
+                  className={`app-nav-link ${page.id}`}
                   onClick={() => setIsOpened(false)}>{pageName}</NavLink>
             })
           }

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -55,10 +55,10 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         </div>
         {!!loggedInUsername && (
           <div className="app-nav-logout">
-            <NavLink to="/change-password" className="change-password-link">
+            <NavLink to="/change-password" className="app-nav-link change-password">
               {translate('auth.changePassword')}
             </NavLink>
-            <NavLink to="/login" onClick={logout} className="logout-link">
+            <NavLink to="/login" onClick={logout} className="app-nav-link logout">
               {translate('auth.logout')} ({loggedInUsername})
             </NavLink>
           </div>

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -55,10 +55,10 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
         </div>
         {!!loggedInUsername && (
           <div className="app-nav-logout">
-            <NavLink to="/change-password" className="app-nav-link change-password">
+            <NavLink to="/change-password" className="app-nav-link app-nav-link-change-password">
               {translate('auth.changePassword')}
             </NavLink>
-            <NavLink to="/login" onClick={logout} className="app-nav-link logout">
+            <NavLink to="/login" onClick={logout} className="app-nav-link app-nav-link-logout">
               {translate('auth.logout')} ({loggedInUsername})
             </NavLink>
           </div>

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -44,11 +44,11 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
             (config?.pages || []).map((page, idx) => {
               const pageName = translate(`pages.${page.id}.title`) || page.id;
               return page?.customLink ?
-                <a href={page?.customLink} target="_blank" key={`page_${idx}`} className={`app-nav-link ${page.id}`}>
+                <a href={page?.customLink} target="_blank" key={`page_${idx}`} className={`app-nav-link app-nav-link-${page.id}`}>
                   {pageName}
                 </a> :
                 <NavLink to={`/${page.id || idx + 1}`} activeClassName="active" key={`page_${idx}`}
-                  className={`app-nav-link ${page.id}`}
+                  className={`app-nav-link app-nav-link-${page.id}`}
                   onClick={() => setIsOpened(false)}>{pageName}</NavLink>
             })
           }

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -120,7 +120,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
           );
           return (
             <td
-              className={field.truncate ? "truncate" : ""}
+              className={`${field.truncate ? "truncate" : ""} ${field.name}`}
               key={`td_${rowIdx}_${fieldIdx}`}
             >
               {renderTableCell(field, item, value)}
@@ -171,6 +171,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
               return (
                 <th
                   key={`th_${field.name}`}
+                  className={`${context.activePage?.id}-${field.name}`}
                   onClick={() => {
                     if (field.queryShortcut) {
                       callbacks.setQueryParam(

--- a/src/components/table/table.comp.tsx
+++ b/src/components/table/table.comp.tsx
@@ -120,7 +120,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
           );
           return (
             <td
-              className={`${field.truncate ? "truncate" : ""} ${field.name}`}
+              className={`${field.truncate ? "truncate" : ""} td-${field.name}`}
               key={`td_${rowIdx}_${fieldIdx}`}
             >
               {renderTableCell(field, item, value)}
@@ -171,7 +171,7 @@ export const Table = withAppContext(({ context, items, fields, pagination, callb
               return (
                 <th
                   key={`th_${field.name}`}
-                  className={`${context.activePage?.id}-${field.name}`}
+                  className={`th-${field.name}`}
                   onClick={() => {
                     if (field.queryShortcut) {
                       callbacks.setQueryParam(


### PR DESCRIPTION
This PR adds CSS classes to various component elements, using encoded field or page names. This makes it easier to apply custom CSS overrides on a per-field or per-page basis.

There are no visual or behavioral changes introduced by this update.