### PR TITLE
Add option to suppress formdialog for customactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,10 @@ A list of extra (non RESTful) endpoints available in your RESTful API. Specifica
 
 > If `customActions` is not empty then for each action RESTool will generate an action button on each data row.
 
+> By default, clicking an action button opens a form dialog where users can input values for the configured fields.
+
+> The `suppressDialog` property can be used to skip showing the form dialog - in this case, no fields will be sent in the request body (an empty object is sent). You can combine this with `requireConfirmation` to show a confirmation dialog instead.
+
 > You may configure the icon of the action by adding an `icon` property. RESTool uses font-awesome and you may use any icon name you want from their collection.
 
 Here's an example for a configuration of 2 custom actions:
@@ -521,14 +525,9 @@ Here's an example for a configuration of 2 custom actions:
       "url": "/character/:id/disable",
       "actualMethod": "post",
       "icon": "minus-circle",
-      "fields": [
-        {
-          "name": "id",
-          "type": "text",
-          "label": "Contact ID",
-          "readonly": true
-        }
-      ]
+      "suppressDialog": true,       // no form dialog will be shown
+      "requireConfirmation": true,  // browser confirmation dialog will be shown
+      "fields": []
     }
   ]
 }

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -721,6 +721,14 @@
             "icon": {
               "type": "string",
               "description": "You may configure the icon of the action. RESTool uses font-awesome and you may use any icon name you want from their collection."
+            },
+            "suppressDialog": {
+              "type": "boolean",
+              "description": "When set to true, the form popup will be suppressed and the action will be executed immediately. Use with requireConfirmation to show a confirmation dialog instead."
+            },
+            "requireConfirmation": {
+              "type": "boolean",
+              "description": "When set to true and suppressDialog is true, shows a confirmation dialog before executing the action. Useful for potentially destructive actions."
             }
           }
         }

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -252,6 +252,8 @@ export interface IConfigCustomAction extends IConfigMethod {
   icon: string;
   dataTransform?: ConfigFunction;
   fields: IConfigInputField[];
+  suppressDialog?: boolean;
+  requireConfirmation?: boolean;
 }
 
 export type IConfigPagination = IConfigQueryPagination | IConfigBodyPagination;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,7 @@
     "common": {
       "actions": "Actions",
       "confirmDelete": "Are you sure you want to delete this item?",
+      "confirmCustomAction": "Are you sure you want to perform this action?",
       "emptyResults": "Nothing to see here. Result is empty.",
       "error": "Error",
       "loading": "Loading...",


### PR DESCRIPTION
Implements #285 

This PR introduces two new properties for custom actions:

- `suppressDialog`: Skip the form popup and execute action immediately
- `requireConfirmation`: Show the browser confirmation dialog before executing

This allows for simpler user interactions when no input fields are needed - instead of showing an empty form dialog, the action can be executed directly from the UI. Common use cases include simple state changes like archive/unarchive, enable/disable, etc.
