### PR TITLE
Improves error message handling on auth pages

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -50,7 +50,7 @@
     main {
       position: relative;
       flex: 1;
-      max-width: calc(100vw - 30px - var(--nav-width));
+      max-width: calc(100vw - var(--nav-width));
 
       @media screen and (max-width: 800px) {
         max-width: 100%;

--- a/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
+++ b/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
@@ -29,10 +29,14 @@ export const ChangePasswordPage = withAppContext(
       }
       try {
         await authService.changePassword(oldPwd, newPwd);
-        toast.success(translate('auth.passwordChanged'));
+        const successMessage = translate('auth.passwordChangeSuccess');
+        if (successMessage) {
+          toast.success(successMessage);
+        }
         replace('/');
-      } catch (error) {
-        toast.error(translate('auth.passwordChangeFailed'));
+      } catch (e) {
+          const errorMessage = translate('auth.passwordChangeFailed') + (e instanceof Error ? `: ${e.message}` : '');
+          toast.error(errorMessage);
       }
     }
 
@@ -50,6 +54,7 @@ export const ChangePasswordPage = withAppContext(
 
     return (
       <div className="change-pwd-page">
+        <h3>{translate('auth.changePasswordHeading')}</h3>
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
             <label>{translate('auth.labels.oldPassword')}</label>

--- a/src/components/auth/changePasswortPage/changePasswortPage.scss
+++ b/src/components/auth/changePasswortPage/changePasswortPage.scss
@@ -7,6 +7,8 @@
     max-width: 100%;
     overflow: auto;
     min-height: 100vh;
+    gap: 20px;
+
     .form-content {
       width: 90%;
       max-width: 540px;
@@ -177,6 +179,7 @@
           padding: 7px 15px;
           text-transform: uppercase;
           font-weight: 400;
+          margin-top: 20px;
         }
       }
     }

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -29,7 +29,10 @@ export const LoginPage = withAppContext(
         const { passwordChangeRequired } = await authService.login(user, pwd);
         setLoggedInUsername(user);
         if (passwordChangeRequired) {
-          toast.info(translate('auth.passwordChangeRequired'));
+          const passwordChangeMessage = translate('auth.passwordChangeRequired');
+          if (passwordChangeMessage) {
+            toast.info(passwordChangeMessage);
+          }
           history.replace('/change-password');
           return;
         }
@@ -39,8 +42,9 @@ export const LoginPage = withAppContext(
         } else {
           history.replace('/');
         }
-      } catch (error) {
-        toast.error(translate('auth.loginFailed'));
+      } catch (e) {
+        const errorMessage = translate('auth.loginFailed') + (e instanceof Error ? `: ${e.message}` : '');
+        toast.error(errorMessage);
         setPwd('');
         return;
       }

--- a/src/components/auth/loginPage/loginPage.scss
+++ b/src/components/auth/loginPage/loginPage.scss
@@ -177,6 +177,7 @@
           padding: 7px 15px;
           text-transform: uppercase;
           font-weight: 400;
+          margin-top: 20px;
         }
       }
     }

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -21,10 +21,14 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
     try {
       await authService.logout();
       setLoggedInUsername(null);
-      toast.info(translate('auth.logoutSuccess'));
+      const successMessage = translate('auth.logoutSuccess');
+      if (successMessage) {
+        toast.info(successMessage);
+      }
       replace('/login');
-    } catch (error) {
-      toast.error(translate('auth.logoutFailed'));
+    } catch (e) {
+      const errorMessage = translate('auth.logoutFailed') + (e instanceof Error ? `: ${e.message}` : '');
+      toast.error(errorMessage);
     }
   }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "auth": {
     "changePassword": "Change Password",
+    "changePasswordHeading": "Please change your password",
     "labels": {
       "confirmPassword": "Confirm New Password",
       "newPassword": "New Password",

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -33,7 +33,8 @@ class AuthService {
         if (response.ok) {
             return { success: true, passwordChangeRequired };
         } else {
-            throw new Error("Login failed");
+            const responseText = await response.text();
+            throw new Error(responseText);
         }
     }
 
@@ -47,7 +48,8 @@ class AuthService {
         if (response.ok) {
             return true;
         } else {
-            throw new Error("Logout failed");
+            const responseText = await response.text();
+            throw new Error(responseText);
         }
     }
 
@@ -76,7 +78,8 @@ class AuthService {
         if (response.ok) {
             return true;
         } else {
-            throw new Error("Password change failed");
+            const responseText = await response.text();
+            throw new Error(responseText);
         }
     }
 }


### PR DESCRIPTION
This small PR improves the handling of error messages for authentication-related actions (login, logout and password change).
It mainly ensures that error messages from the backend (e.g. incorrect credentials or too many failed login attempts) are displayed in the message toast.