### PR TITLE
Fix unauthorized redirect handling

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -60,6 +60,20 @@ function App() {
       httpService.errorMessageDataPath = remoteConfig.errorMessageDataPath || '';
       httpService.unauthorizedRedirectUrl = remoteConfig.unauthorizedRedirectUrl || '';
       httpService.requestHeaders = remoteConfig.requestHeaders || {};
+      httpService.setUnauthorizedHandler({
+        onUnauthorizedRequest: (currentPath) => {
+          // Clear context before navigation
+          setActivePage(null);
+
+          if (httpService.unauthorizedRedirectUrl) {
+            // Legacy flow takes precedence
+            const redirectUrl = httpService.unauthorizedRedirectUrl.replace(':returnUrl', encodeURIComponent(currentPath));
+            document.location.href = redirectUrl;
+          } else if (!currentPath.startsWith('/login')) {
+            document.location.href = `#/login?return=${encodeURIComponent(currentPath)}`;
+          }
+        }
+      });
       
       authService.baseUrl = remoteConfig.baseUrl || '';
       if (remoteConfig.auth) {


### PR DESCRIPTION
Previously, when a request returned 401, the app redirected to login within the HttpService, but the page component kept a stale "activePage" context. This led to timing issues where the old context would trigger additional API calls with the old context, causing UI inconsistencies.

This PR fixes the issue by adding an unauthorized callback for the HttpService, so that the page component clears context before navigation occurs. This ensures proper state management during auth redirects while maintaining support for both legacy and default navigation flows.
