### PR TITLE
Add notificationStyle (toast/banner) option and centralized notification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Here's a detailed list of properties you could add to your configuration file (j
 | unauthorizedRedirectUrl | `string` | false | Legacy option that takes priority over `auth` config: URL to redirect to when the API returns a 401 (Unauthorized) error. Use `:returnUrl` to pass a return location. For example: `"/login?return=:returnUrl"` |
 | auth | `object` | false | Built-in authentication configuration (used only if `unauthorizedRedirectUrl` is not set). See [Auth Config](#auth-config) below. |
 | favicon | `string` | false | A URL for you app's favicon. |
+| notificationStyle | `string` ("banner" \| "toast") | false | Controls how notifications (success/error messages) are displayed. `"banner"` shows a fixed banner within the content area, while `"toast"` shows floating notifications in the top-center. Default is `"toast"`. |
 | customStyles | `object` | false | [Custom styles](#custom-styles) |
 | customLabels | `object` | false | [Custom labels](#custom-labels) <br> ⚠️ Deprecated. Use i18n language files instead. See [Internationalization (i18n)](#internationalization-i18n) section. |
 | customLink | `string` | false | External Link for navigation item (instead of default page app) |

--- a/src/assets/schemas/config.schema.json
+++ b/src/assets/schemas/config.schema.json
@@ -29,6 +29,12 @@
       "type": "string",
       "description": "Path to navigate to when the api returns a 401 (Unauthorized) error. You can use :returnUrl to pass a return location. For example: \"/login/myLoginPage?return=:returnUrl\""
     },
+    "notificationStyle": {
+      "type": "string",
+      "enum": ["banner", "toast"],
+      "default": "toast",
+      "description": "The style of notifications to use throughout the application. Use 'banner' for fixed banner at top of page, or 'toast' for temporary pop-up notifications"
+    },
     "auth": {
       "loginEndpoint": {
         "type": "string",

--- a/src/common/models/config.model.ts
+++ b/src/common/models/config.model.ts
@@ -20,6 +20,8 @@ export interface IAuthConfig {
   };
 }
 
+export type NotificationStyle = 'toast' | 'banner';
+
 export interface IConfig {
   remoteUrl?: string;
   name: string;
@@ -32,6 +34,7 @@ export interface IConfig {
   pages: IConfigPage[];
   customStyles?: ICustomStyles;
   customLabels?: ICustomLabels;
+  notificationStyle?: NotificationStyle;
 }
 
 export interface ICustomStyles {

--- a/src/common/models/notification.types.ts
+++ b/src/common/models/notification.types.ts
@@ -1,0 +1,6 @@
+export type NotificationType = 'success' | 'error' | 'info';
+
+export interface INotification {
+  type: NotificationType;
+  message: string;
+}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { ToastContainer, toast } from 'react-toastify';
 import ConfigService from '../services/config.service';
+import { notificationService } from '../services/notification.service';
 import { IConfig, IConfigPage } from '../common/models/config.model';
 import { Page } from '../components/page/page.comp';
 import { Navigation } from '../components/navigation/navigation.comp';
@@ -55,6 +56,8 @@ function App() {
       } else {
         remoteConfig = url ? await ConfigService.getRemoteConfig(url) : await ConfigService.loadDefaultConfig();
       }
+
+      notificationService.setMode(remoteConfig.notificationStyle !== 'banner');
 
       httpService.baseUrl = remoteConfig.baseUrl || '';
       httpService.errorMessageDataPath = remoteConfig.errorMessageDataPath || '';
@@ -121,9 +124,9 @@ function App() {
   useEffect(() => {
     const { isValid, errorMessage } = ConfigService.validateConfig(config);
 
-    if (!isValid) {
+    if (!isValid && errorMessage) {
       setError(errorMessage);
-      toast.error(errorMessage);
+      notificationService.error(errorMessage);
       return;
     }
   }, [config]);
@@ -155,7 +158,9 @@ function App() {
                     <Redirect path="/" to={`/${config?.pages?.[0]?.id || '1'}`} />
                   </Switch>
               </div>
-              <ToastContainer position={toast.POSITION.TOP_CENTER} autoClose={4000} draggable={false} />
+              {config.notificationStyle !== 'banner' && (
+                <ToastContainer position={toast.POSITION.TOP_CENTER} autoClose={4000} draggable={false} />
+              )}
             </Router>
           </AppContext.Provider>
       }

--- a/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
+++ b/src/components/auth/changePasswortPage/changePasswortPage.comp.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { usePageTranslation } from '../../../hooks/usePageTranslation';
 import { Button } from '../../button/button.comp';
-import { toast } from 'react-toastify';
+import { notificationService } from '../../../services/notification.service';
 
 import './changePasswortPage.scss';
 import { withAppContext } from '../../withContext/withContext.comp';
+import { NotificationBanner } from '../../notificationBanner/notificationBanner.comp';
 import { IAppContext } from '../../app.context';
 
 interface IProps {
@@ -24,15 +25,15 @@ export const ChangePasswordPage = withAppContext(
     async function submitForm(e: React.FormEvent<HTMLFormElement>) {
       e.preventDefault();
       if (newPwd !== confirmPwd) {
-        toast.error(translate('auth.passwordMismatch'));
+        notificationService.error(translate('auth.passwordMismatch'));
         return;
       }
       try {
         await authService.changePassword(oldPwd, newPwd);
-        toast.success(translate('auth.passwordChanged'));
+        notificationService.success(translate('auth.passwordChanged'));
         replace('/');
       } catch (error) {
-        toast.error(translate('auth.passwordChangeFailed'));
+        notificationService.error(translate('auth.passwordChangeFailed'));
       }
     }
 
@@ -50,6 +51,7 @@ export const ChangePasswordPage = withAppContext(
 
     return (
       <div className="change-pwd-page">
+        {context.config?.notificationStyle === 'banner' && <NotificationBanner />}
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
             <label>{translate('auth.labels.oldPassword')}</label>

--- a/src/components/auth/changePasswortPage/changePasswortPage.scss
+++ b/src/components/auth/changePasswortPage/changePasswortPage.scss
@@ -10,6 +10,10 @@
     .form-content {
       width: 90%;
       max-width: 540px;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
   
       section {
         padding: 20px;

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -30,8 +30,7 @@ export const LoginPage = withAppContext(
         const { passwordChangeRequired } = await authService.login(user, pwd);
         setLoggedInUsername(user);
         if (passwordChangeRequired) {
-          notificationService.info(translate('auth.passwordChangeRequired'));
-          history.replace('/change-password');
+          history.replace('/change-password?showPasswordMessage=true');
           return;
         }
         // Only redirect if returnUrl exists and is not /login
@@ -41,7 +40,7 @@ export const LoginPage = withAppContext(
           history.replace('/');
         }
       } catch (error) {
-        const errorMessage = translate('auth.loginFailed') + (e instanceof Error ? `: ${e.message}` : '');
+        const errorMessage = translate('auth.loginFailed') + (error instanceof Error ? `: ${error.message}` : '');
         notificationService.error(errorMessage);
         setPwd('');
         return;

--- a/src/components/auth/loginPage/loginPage.comp.tsx
+++ b/src/components/auth/loginPage/loginPage.comp.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { usePageTranslation } from '../../../hooks/usePageTranslation';
 import { Button } from '../../button/button.comp';
-import { toast } from 'react-toastify';
+import { notificationService } from '../../../services/notification.service';
 
 import './loginPage.scss';
 import { withAppContext } from '../../withContext/withContext.comp';
+import { NotificationBanner } from '../../notificationBanner/notificationBanner.comp';
 import { IAppContext } from '../../app.context';
 
 interface IProps {
@@ -29,7 +30,7 @@ export const LoginPage = withAppContext(
         const { passwordChangeRequired } = await authService.login(user, pwd);
         setLoggedInUsername(user);
         if (passwordChangeRequired) {
-          toast.info(translate('auth.passwordChangeRequired'));
+          notificationService.info(translate('auth.passwordChangeRequired'));
           history.replace('/change-password');
           return;
         }
@@ -40,7 +41,7 @@ export const LoginPage = withAppContext(
           history.replace('/');
         }
       } catch (error) {
-        toast.error(translate('auth.loginFailed'));
+        notificationService.error(translate('auth.loginFailed'));
         setPwd('');
         return;
       }
@@ -56,6 +57,7 @@ export const LoginPage = withAppContext(
 
     return (
       <div className="auth-page">
+        {context.config?.notificationStyle === 'banner' && <NotificationBanner />}
         <form className='form-content' onSubmit={submitForm}>
           <div className='form-row row'>
             <label>{translate('auth.labels.user')}</label>

--- a/src/components/auth/loginPage/loginPage.scss
+++ b/src/components/auth/loginPage/loginPage.scss
@@ -10,6 +10,10 @@
     .form-content {
       width: 90%;
       max-width: 540px;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
   
       section {
         padding: 20px;

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -46,7 +46,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
   const [loading, setLoading] = useState<boolean>(true);
   const [formFields, setFormFields] = useState<IConfigInputField[]>([]);
   const [finalRawData, setFinalRawData] = useState<any>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [formErrorMessage, setFormErrorMessage] = useState<string | null>(null);
   const pageHeaders: any = activePage?.requestHeaders || {};
   const customLabels: ICustomLabels | undefined = { ...config?.customLabels, ...activePage?.customLabels };
 
@@ -77,7 +77,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
       } catch (e) {
         console.error(translatePage('forms.errors.loadItemFailed'), e);
         if (config?.notificationStyle === 'banner') {
-          setErrorMessage(translatePage('forms.errors.loadItemFailed'));
+          setFormErrorMessage(translatePage('forms.errors.loadItemFailed'));
         } else {
           notificationService.error(translatePage('forms.errors.loadItemFailed'));
         }
@@ -146,7 +146,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
   }
 
   async function submitForm(e: any) {
-    setErrorMessage(null);
+    setFormErrorMessage(null);
     e.preventDefault();
 
     const finalObject: any = (methodConfig as IConfigPutMethod).includeOriginalFields ? Object.assign({}, finalRawData) : {};
@@ -222,7 +222,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
 
     if (validationError) {
       if (config?.notificationStyle === 'banner') {
-        setErrorMessage(validationError);
+        setFormErrorMessage(validationError);
       } else {
         notificationService.error(validationError);
       }
@@ -234,14 +234,11 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
     try {
       let body = containFiles ? formData : unflatten(finalObject);
       await submitCallback(body, containFiles, queryParams);
-      if (successMessage) {
-        notificationService.success(successMessage);
-      }
-
+      notificationService.success(successMessage);
       closeCallback(true);
     } catch (e) {
       if (config?.notificationStyle === 'banner') {
-        setErrorMessage((e as Error).message);
+        setFormErrorMessage((e as Error).message);
       } else {
         notificationService.error((e as Error).message);
       }
@@ -251,7 +248,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
   }
 
   function formChanged(fieldName: string, value: any) {
-    setErrorMessage(null);
+    setFormErrorMessage(null);
     let updatedFormFields: IConfigInputField[] = [...formFields];
     
     // First update the field value
@@ -286,7 +283,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
       show={true}
       className="form-popup"
       closeCallback={() => {
-        setErrorMessage(null);
+        setFormErrorMessage(null);
         closeCallback(false);
       }}
       customLabels={customLabels}
@@ -311,11 +308,11 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
                     );
                   })
                 }
-                {config?.notificationStyle === 'banner' && errorMessage && (
+                {config?.notificationStyle === 'banner' && formErrorMessage && (
                   <div className="form-notification-banner error">
                     <div className="banner-content">
                       <i className="fa fa-exclamation-circle" aria-hidden="true"></i>
-                      <span>{errorMessage}</span>
+                      <span>{formErrorMessage}</span>
                     </div>
                   </div>
                 )}

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -295,6 +295,14 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
             loading ?
               <Loader /> :
               <form onSubmit={submitForm}>
+                {config?.notificationStyle === 'banner' && formErrorMessage && (
+                  <div className="form-notification-banner error">
+                    <div className="banner-content">
+                      <i className="fa fa-exclamation-circle" aria-hidden="true"></i>
+                      <span>{formErrorMessage}</span>
+                    </div>
+                  </div>
+                )}
                 {
                   formFields.map((field, idx) => {
                     if (!shouldFieldBeVisible(field, formFields)) return null;
@@ -308,14 +316,6 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
                     );
                   })
                 }
-                {config?.notificationStyle === 'banner' && formErrorMessage && (
-                  <div className="form-notification-banner error">
-                    <div className="banner-content">
-                      <i className="fa fa-exclamation-circle" aria-hidden="true"></i>
-                      <span>{formErrorMessage}</span>
-                    </div>
-                  </div>
-                )}
                 <div className="buttons-wrapper center">
                   <Button type="submit" onClick={submitForm}>
                     {(customLabels?.buttons?.submitItem ||

--- a/src/components/formPopup/formPopup.comp.tsx
+++ b/src/components/formPopup/formPopup.comp.tsx
@@ -299,7 +299,7 @@ export const FormPopup = withAppContext(({ context, title, type, successMessage,
                   <div className="form-notification-banner error">
                     <div className="banner-content">
                       <i className="fa fa-exclamation-circle" aria-hidden="true"></i>
-                      <span>{formErrorMessage}</span>
+                      <span className="banner-message">{formErrorMessage}</span>
                     </div>
                   </div>
                 )}

--- a/src/components/formPopup/formPopup.scss
+++ b/src/components/formPopup/formPopup.scss
@@ -1,6 +1,28 @@
 @import '../../common/styles//functions.scss';
 
 .form-popup {
+  .form-notification-banner {
+    padding: 16px;
+    text-align: center;
+    margin-bottom: 16px;  
+
+    &.error {
+      background-color: #f8d7da;
+      color: dc3545;
+    }
+
+    .banner-content {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+    }
+
+    .fa {
+      margin-right: 4px;
+    }
+  }
+
   .popup-content {
     width: 90%;
     max-width: 740px;

--- a/src/components/formPopup/formPopup.scss
+++ b/src/components/formPopup/formPopup.scss
@@ -3,8 +3,6 @@
 .form-popup {
   .form-notification-banner {
     padding: 16px;
-    text-align: center;
-    margin-bottom: 16px;  
 
     &.error {
       background-color: #f8d7da;
@@ -14,7 +12,6 @@
     .banner-content {
       display: flex;
       align-items: center;
-      justify-content: center;
       gap: 8px;
     }
 

--- a/src/components/formPopup/formPopup.scss
+++ b/src/components/formPopup/formPopup.scss
@@ -6,7 +6,7 @@
 
     &.error {
       background-color: #f8d7da;
-      color: dc3545;
+      color: #dc3545;
     }
 
     .banner-content {

--- a/src/components/formRow/formRow.comp.tsx
+++ b/src/components/formRow/formRow.comp.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { orderBy } from "natural-orderby";
-import { toast } from "react-toastify";
+import { notificationService } from "../../services/notification.service";
 import { Multiselect } from "multiselect-react-dropdown";
 
 import {
@@ -143,7 +143,7 @@ export const FormRow = withAppContext(
           });
         }
       } catch (e) {
-        toast.error((e as Error).message);
+        notificationService.error((e as Error).message);
       }
     }
 

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -21,7 +21,6 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
     try {
       await authService.logout();
       setLoggedInUsername(null);
-      notificationService.info(translate('auth.logoutSuccess'));
       replace('/login');
     } catch (e) {
       const errorMessage = translate('auth.logoutFailed') + (e instanceof Error ? `: ${e.message}` : '');

--- a/src/components/navigation/navigation.comp.tsx
+++ b/src/components/navigation/navigation.comp.tsx
@@ -4,7 +4,7 @@ import { usePageTranslation } from '../../hooks/usePageTranslation';
 import { IAppContext } from '../app.context';
 import { withAppContext } from '../withContext/withContext.comp';
 import { Button } from '../button/button.comp';
-import { toast } from 'react-toastify';
+import { notificationService } from '../../services/notification.service';
 
 import './navigation.scss';
 
@@ -21,10 +21,10 @@ const NavigationComp = ({ context: { config, authService, loggedInUsername, setL
     try {
       await authService.logout();
       setLoggedInUsername(null);
-      toast.info(translate('auth.logoutSuccess'));
+      notificationService.info(translate('auth.logoutSuccess'));
       replace('/login');
     } catch (error) {
-      toast.error(translate('auth.logoutFailed'));
+      notificationService.error(translate('auth.logoutFailed'));
     }
   }
 

--- a/src/components/notificationBanner/notificationBanner.comp.tsx
+++ b/src/components/notificationBanner/notificationBanner.comp.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { INotification } from '../../common/models/notification.types';
+import { notificationService } from '../../services/notification.service';
+import './notificationBanner.scss';
+
+export const NotificationBanner = () => {
+  const [notification, setNotification] = useState<INotification | null>(null);
+  const [visible, setVisible] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    const listener = notificationService.subscribe((newNotification) => {
+      setNotification(newNotification);
+      setVisible(!!newNotification);
+    });
+
+    return () => {
+      notificationService.unsubscribe(listener);
+    };
+  }, []);
+
+  // Clear notification on route change
+  useEffect(() => {
+    setNotification(null);
+    setVisible(false);
+  }, [location]);
+
+  if (!notification) {
+    return null;
+  }
+
+  const getIcon = () => {
+    switch (notification.type) {
+      case 'success':
+        return 'check-circle';
+      case 'error':
+        return 'exclamation-circle';
+      case 'info':
+        return 'info-circle';
+      default:
+        return 'info-circle';
+    }
+  };
+
+  return (
+    <div className={`notification-banner ${notification.type} ${visible ? 'visible' : ''}`}>
+      <div className="banner-content">
+        <i className={`fa fa-${getIcon()}`} aria-hidden="true"></i>
+        <span>{notification.message}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/notificationBanner/notificationBanner.comp.tsx
+++ b/src/components/notificationBanner/notificationBanner.comp.tsx
@@ -47,7 +47,7 @@ export const NotificationBanner = () => {
     <div className={`notification-banner ${notification.type} ${visible ? 'visible' : ''}`}>
       <div className="banner-content">
         <i className={`fa fa-${getIcon()}`} aria-hidden="true"></i>
-        <span>{notification.message}</span>
+        <span className="banner-message">{notification.message}</span>
       </div>
     </div>
   );

--- a/src/components/notificationBanner/notificationBanner.scss
+++ b/src/components/notificationBanner/notificationBanner.scss
@@ -29,7 +29,6 @@
   }
 
   .banner-content {
-    max-width: 1200px;
     margin: 0 auto;
     display: flex;
     align-items: center;

--- a/src/components/notificationBanner/notificationBanner.scss
+++ b/src/components/notificationBanner/notificationBanner.scss
@@ -33,7 +33,6 @@
     margin: 0 auto;
     display: flex;
     align-items: center;
-    justify-content: center;
     gap: 8px;
   }
 

--- a/src/components/notificationBanner/notificationBanner.scss
+++ b/src/components/notificationBanner/notificationBanner.scss
@@ -1,0 +1,43 @@
+.notification-banner {
+  padding: 16px;
+  text-align: center;
+  margin-bottom: 16px;
+  flex: 0 0 auto;
+  width: max-content;
+  width: 100%;
+  align-self: center;
+  transition: opacity 0.3s ease-in-out;
+  opacity: 0;
+  
+  &.visible {
+    opacity: 1;
+  }
+
+  &.success {
+    background-color: #d4edda;
+    color: #28a745;
+  }
+
+  &.error {
+    background-color: #f8d7da;
+    color: #dc3545;
+  }
+
+  &.info {
+    background-color: #d1ecf1;
+    color: #17a2b8;
+  }
+
+  .banner-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .fa {
+    margin-right: 8px;
+  }
+}

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -256,9 +256,7 @@ const PageComp = ({ context }: IProps) => {
     try {
       const success = await performAction({}, rawData, action, false);
       if (success) {
-        if (customActionSuccessMessage) {
-          notificationService.success(customActionSuccessMessage);
-        }
+        notificationService.success(customActionSuccessMessage);
         refreshPageData();
       }
     } catch (e) {
@@ -529,10 +527,7 @@ const PageComp = ({ context }: IProps) => {
       });
 
       if (success) {
-        if (deleteItemSuccessMessage) {
-          notificationService.success(deleteItemSuccessMessage);
-        }
-
+        notificationService.success(deleteItemSuccessMessage);
         refreshPageData();
       }
     } catch (e) {

--- a/src/components/page/page.comp.tsx
+++ b/src/components/page/page.comp.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { usePageTranslation } from "../../hooks/usePageTranslation";
 import { useParams, useHistory } from "react-router-dom";
 import * as QueryString from "query-string";
-import { toast } from "react-toastify";
+import { notificationService } from "../../services/notification.service";
 import { orderBy } from "natural-orderby";
 import { find, get, remove } from "lodash";
 
@@ -26,6 +26,7 @@ import {
   IBodyPaginationState,
 } from "../../common/models/states.model";
 import { withAppContext } from "../withContext/withContext.comp";
+import { NotificationBanner } from "../notificationBanner/notificationBanner.comp";
 import { Loader } from "../loader/loader.comp";
 import { dataHelpers } from "../../helpers/data.helpers";
 import { paginationHelpers } from "../../helpers/pagination.helpers";
@@ -256,12 +257,12 @@ const PageComp = ({ context }: IProps) => {
       const success = await performAction({}, rawData, action, false);
       if (success) {
         if (customActionSuccessMessage) {
-          toast.success(customActionSuccessMessage);
+          notificationService.success(customActionSuccessMessage);
         }
         refreshPageData();
       }
     } catch (e) {
-      toast.error((e as Error).message);
+      notificationService.error((e as Error).message);
     }
   }
 
@@ -529,13 +530,13 @@ const PageComp = ({ context }: IProps) => {
 
       if (success) {
         if (deleteItemSuccessMessage) {
-          toast.success(deleteItemSuccessMessage);
+          notificationService.success(deleteItemSuccessMessage);
         }
 
         refreshPageData();
       }
     } catch (e) {
-      toast.error((e as Error).message);
+      notificationService.error((e as Error).message);
     }
   }
 
@@ -923,6 +924,7 @@ const PageComp = ({ context }: IProps) => {
 
     return (
       <React.Fragment>
+        {config?.notificationStyle === 'banner' && <NotificationBanner />}
         <QueryParams
           initialParams={queryParams}
           paginationConfig={paginationConfig}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,9 +13,7 @@
     "loginFailed": "Login failed",
     "logout": "Logout",
     "logoutFailed": "Logout failed",
-    "logoutSuccess": "Logged out successfully",
     "passwordChangeRequired": "Password change required",
-    "passwordChanged": "Password changed successfully",
     "passwordChangeFailed": "Password change failed",
     "passwordMismatch": "Confirmed password does not match",
     "placeholders": {

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,0 +1,67 @@
+import { toast } from 'react-toastify';
+import { INotification, NotificationType } from '../common/models/notification.types';
+
+class NotificationService extends EventTarget {
+  private useToast: boolean = true;
+  private static readonly NOTIFICATION_EVENT = 'notification';
+
+  constructor() {
+    super();
+  }
+
+  setMode(useToast: boolean) {
+    this.useToast = useToast;
+  }
+
+  private notify(type: NotificationType, message: string) {
+    if (this.useToast) {
+      switch (type) {
+        case 'success':
+          toast.success(message);
+          break;
+        case 'error':
+          toast.error(message);
+          break;
+        case 'info':
+          toast.info(message);
+          break;
+      }
+    } else {
+      const notification: INotification | null = message ? { type, message } : null;
+      this.dispatchEvent(new CustomEvent(NotificationService.NOTIFICATION_EVENT, { 
+        detail: notification
+      }));
+    }
+  }
+
+  success(message: string) {
+    this.notify('success', message);
+  }
+
+  error(message: string) {
+    this.notify('error', message);
+  }
+
+  info(message: string) {
+    this.notify('info', message);
+  }
+
+  clear() {
+    this.notify('info', '');
+  }
+
+  subscribe(callback: (notification: INotification | null) => void) {
+    const listener = ((event: Event) => {
+      const customEvent = event as CustomEvent<INotification | null>;
+      callback(customEvent.detail);
+    });
+    this.addEventListener(NotificationService.NOTIFICATION_EVENT, listener);
+    return listener; // Return the listener so it can be used for unsubscribe
+  }
+
+  unsubscribe(listener: EventListener) {
+    this.removeEventListener(NotificationService.NOTIFICATION_EVENT, listener);
+  }
+}
+
+export const notificationService = new NotificationService();

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -15,6 +15,10 @@ class NotificationService extends EventTarget {
 
   private notify(type: NotificationType, message: string) {
     if (this.useToast) {
+      if (!message) {
+        toast.dismiss(); // Clear all toasts if message is empty
+        return;
+      }
       switch (type) {
         case 'success':
           toast.success(message);


### PR DESCRIPTION
Implement #296 

Adds `notificationStyle` config option with "toast" (default) or "banner" modes.
Introduces a centralized notificationService for managing notifications.
- "toast": current floating top-center behavior
- "banner": fixed, persistent notifications (above tables/cards or inside forms) until navigation/refresh

Note: Please consider merging #299 first. This PR will need to be updated to resolve any conflicts.